### PR TITLE
Update changelog automation for renamed files and add compatibility info

### DIFF
--- a/.github/workflows/validate-changelog.yml
+++ b/.github/workflows/validate-changelog.yml
@@ -22,7 +22,7 @@ jobs:
         continue-on-error: true
         with:
           file: ./changelog.json
-          schema: ./changelog-items/announcement-schema.json
+          schema: ./changelog_schema/announcement-schema.json
       - name: Capture validation outcome
         id: capture-outcome
         run: |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ Guidance for Claude Code (claude.ai/code) when working in this repository.
 
 This repo is the canonical source of ZenML release metadata:
 - `changelog.json` feeds the ZenML dashboard "What’s New" widget.
-- `gitbook-release-notes/oss.md` and `gitbook-release-notes/pro.md` power GitBook docs for OSS and Pro.
+- `gitbook-release-notes/server-sdk.md` and `gitbook-release-notes/pro-control-plane.md` power GitBook docs for OSS and Pro.
 - `.github/workflows/` orchestrates automated changelog generation from upstream releases.
 - `changelog_schema/` defines and documents the JSON schema for announcements.
 
@@ -15,8 +15,8 @@ This repo is the canonical source of ZenML release metadata:
 - `changelog.json` — Array of announcements consumed by the dashboard.
 - `.image_state` — Persists rotating image index (1–49) for release note headers.
 - `gitbook-release-notes/`
-  - `oss.md` — OSS/UI release notes (zenml, zenml-dashboard).
-  - `pro.md` — Pro/Cloud release notes (zenml-cloud-ui, zenml-cloud-api).
+  - `server-sdk.md` — OSS/UI release notes (zenml, zenml-dashboard).
+  - `pro-control-plane.md` — Pro/Cloud release notes (zenml-cloud-ui, zenml-cloud-api).
   - `README.md` — Notes for GitBook syncing.
 - `changelog_schema/`
   - `announcement-schema.json` — Validation schema for `changelog.json`.
@@ -53,8 +53,8 @@ This repo is the canonical source of ZenML release metadata:
    - Add a new object with required fields: `id` (next sequential number), `slug`, `title`, `description`, `published_at` (ISO8601 with `Z`), `audience` (`oss|pro|all`), `labels` (`bugfix|deprecation|improvement|feature`).
    - Optional fields: `feature_image_url`, `learn_more_url`, `docs_url`, `highlight_until`, `should_highlight`, `video_url`, `published`.
 2. Update release notes:
-   - OSS: insert a new section at the top of `gitbook-release-notes/oss.md` after frontmatter.
-   - Pro: insert at the top of `gitbook-release-notes/pro.md` after frontmatter.
+   - OSS: insert a new section at the top of `gitbook-release-notes/server-sdk.md` after frontmatter.
+   - Pro: insert at the top of `gitbook-release-notes/pro-control-plane.md` after frontmatter.
 3. Validate locally (recommended): use `cardinalby/schema-validator-action@v3` or run a local `jsonschema` check against `changelog_schema/announcement-schema.json`.
 4. Open a PR; `validate-changelog.yml` will re-validate `changelog.json`.
 

--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ zenml-changelog/
 ├── changelog.json                  # Announcement entries consumed by the dashboard
 ├── .image_state                    # Tracks rotating header image (1-49)
 ├── gitbook-release-notes/
-│   ├── oss.md                      # OSS + dashboard release notes
-│   ├── pro.md                      # Pro/Cloud release notes
+│   ├── server-sdk.md               # OSS + dashboard release notes
+│   ├── pro-control-plane.md        # Pro/Cloud release notes
 │   └── README.md
 ├── changelog_schema/
 │   ├── announcement-schema.json    # JSON Schema for changelog.json
@@ -31,7 +31,7 @@ flowchart TD
     A[Source repo release] -->|repository_dispatch<br/>event_type: release-published| B[process-release.yml]
     B --> C[Run update_changelog.py]
     C --> D[changelog.json]
-    C --> E[gitbook-release-notes/oss.md or pro.md]
+    C --> E[gitbook-release-notes/server-sdk.md or pro-control-plane.md]
     D --> F[Schema validation]
     B --> G[Create PR<br/>changelog/{repo}-{tag}]
 ```
@@ -44,15 +44,15 @@ flowchart TD
 
 | Source repository | Type | Files updated here |
 | --- | --- | --- |
-| `zenml-io/zenml` | OSS core | `changelog.json`, `gitbook-release-notes/oss.md` |
-| `zenml-io/zenml-dashboard` | OSS UI | `changelog.json`, `gitbook-release-notes/oss.md` |
-| `zenml-io/zenml-cloud-ui` | Pro UI | `changelog.json`, `gitbook-release-notes/pro.md` |
-| `zenml-io/zenml-cloud-api` | Pro API | `changelog.json`, `gitbook-release-notes/pro.md` |
+| `zenml-io/zenml` | OSS core | `changelog.json`, `gitbook-release-notes/server-sdk.md` |
+| `zenml-io/zenml-dashboard` | OSS UI | `changelog.json`, `gitbook-release-notes/server-sdk.md` |
+| `zenml-io/zenml-cloud-ui` | Pro UI | `changelog.json`, `gitbook-release-notes/pro-control-plane.md` |
+| `zenml-io/zenml-cloud-api` | Pro API | `changelog.json`, `gitbook-release-notes/pro-control-plane.md` |
 
 ## Manual vs Automated Entries
 
 - **Automated** (preferred): Triggered by releases; creates a PR with new JSON entries and markdown sections. Reviewers verify summaries, labels, and formatting before merge.
-- **Manual**: Edit `changelog.json` (add new object with required fields) and prepend a section to `gitbook-release-notes/oss.md` or `pro.md` after frontmatter. Run validation before opening a PR.
+- **Manual**: Edit `changelog.json` (add new object with required fields) and prepend a section to `gitbook-release-notes/server-sdk.md` or `pro-control-plane.md` after frontmatter. Run validation before opening a PR.
 
 ## Required Secrets and Setup
 

--- a/gitbook-release-notes/pro-control-plane.md
+++ b/gitbook-release-notes/pro-control-plane.md
@@ -22,6 +22,8 @@ See what's new and improved in version 0.12.19.
 
 * General maintenance and release preparation (#462)
 
+> **Compatibility:** Requires ZenML Server and SDK v0.85.0 or later.
+
 ***
 
 ## 0.12.18 (2025-11-12)
@@ -38,6 +40,8 @@ See what's new and improved in version 0.12.18.
 ### What's Changed
 
 * General maintenance and release preparation (#460)
+
+> **Compatibility:** Requires ZenML Server and SDK v0.85.0 or later.
 
 ***
 
@@ -73,6 +77,8 @@ See what's new and improved in version 0.12.17.
 * Enhanced authentication flexibility (#453, #454)
 * Better Codespace development experience (#455)
 
+> **Compatibility:** Requires ZenML Server and SDK v0.85.0 or later.
+
 ***
 
 ## 0.12.16 (2025-10-27)
@@ -89,6 +95,8 @@ See what's new and improved in version 0.12.16.
 ### What's Changed
 
 * General maintenance and release preparation (#449)
+
+> **Compatibility:** Requires ZenML Server and SDK v0.85.0 or later.
 
 ***
 
@@ -107,6 +115,8 @@ See what's new and improved in version 0.12.15.
 
 * Filter long user avatar URLs at source for older workspace versions (<= 0.90.0) (#447)
 
+> **Compatibility:** Requires ZenML Server and SDK v0.85.0 or later.
+
 ***
 
 ## 0.12.14 (2025-10-02)
@@ -124,6 +134,8 @@ See what's new and improved in version 0.12.14.
 
 * General maintenance and release preparation (#446)
 
+> **Compatibility:** Requires ZenML Server and SDK v0.85.0 or later.
+
 ***
 
 ## 0.12.12 (2025-09-16)
@@ -137,6 +149,8 @@ See what's new and improved in version 0.12.12.
 * Service accounts can now invite users
 * Improved automation capabilities
 
+> **Compatibility:** Requires ZenML Server and SDK v0.85.0 or later.
+
 ***
 
 ## 0.12.11 (2025-09-15)
@@ -149,6 +163,8 @@ See what's new and improved in version 0.12.11.
 
 * Service accounts can invite users
 * Enhanced collaboration capabilities
+
+> **Compatibility:** Requires ZenML Server and SDK v0.85.0 or later.
 
 ***
 
@@ -170,6 +186,8 @@ See what's new and improved in version 0.12.10.
 * Default workspace version updates (#434)
 * Run template resource improvements (#435)
 
+> **Compatibility:** Requires ZenML Server and SDK v0.85.0 or later.
+
 ***
 
 ## 0.12.9
@@ -187,6 +205,8 @@ See what's new and improved in version 0.12.9.
 
 * General maintenance and release preparation (#431)
 
+> **Compatibility:** Requires ZenML Server and SDK v0.85.0 or later.
+
 ***
 
 ## 0.12.8
@@ -200,6 +220,8 @@ See what's new and improved in version 0.12.8.
 * Workspaces can now be renamed
 * Improved workspace management
 
+> **Compatibility:** Requires ZenML Server and SDK v0.85.0 or later.
+
 ***
 
 ## 0.12.7
@@ -212,6 +234,8 @@ See what's new and improved in version 0.12.7.
 
 * Schedule RBAC enabled
 * Team viewer default role added
+
+> **Compatibility:** Requires ZenML Server and SDK v0.85.0 or later.
 
 ***
 
@@ -241,6 +265,8 @@ See what's new and improved in version 0.12.6.
 
 * Service account fixes and membership filtering (#424)
 
+> **Compatibility:** Requires ZenML Server and SDK v0.85.0 or later.
+
 ***
 
 ## 0.12.5
@@ -258,6 +284,8 @@ See what's new and improved in version 0.12.5.
 
 * User onboarding tracking (#414)
 * Dependency updates (#418)
+
+> **Compatibility:** Requires ZenML Server and SDK v0.85.0 or later.
 
 ***
 
@@ -277,6 +305,8 @@ See what's new and improved in version 0.12.3.
 * Codespace cleanup automation (#403)
 * Workspace default version updates (#407)
 
+> **Compatibility:** Requires ZenML Server and SDK v0.85.0 or later.
+
 ***
 
 ## 0.12.2
@@ -294,6 +324,8 @@ See what's new and improved in version 0.12.2.
 
 * Workspace storage usage count, limiting, and cleanup
 * Better resource management
+
+> **Compatibility:** Requires ZenML Server and SDK v0.85.0 or later.
 
 ***
 
@@ -330,3 +362,13 @@ See what's new and improved in version 0.12.0.
 * Terraform infrastructure support (#396)
 * RBAC improvements (#392)
 * Team member management (#397)
+
+</details>
+
+### Breaking Changes
+
+* Kubernetes Orchestrator Compatibility: Client and orchestrator pod versions must match exactly
+
+> **Compatibility:** Requires ZenML Server and SDK v0.85.0 or later.
+
+***

--- a/gitbook-release-notes/server-sdk.md
+++ b/gitbook-release-notes/server-sdk.md
@@ -49,6 +49,8 @@ See what's new and improved in version 0.91.2.
 
 </details>
 
+[View full release on GitHub](https://github.com/zenml-io/zenml/releases/tag/0.91.2)
+
 ***
 ## 0.91.1 (2025-11-11)
 
@@ -105,6 +107,8 @@ See what's new and improved in version 0.91.1.
 * Case-sensitivity issues when updating entity names ([#4140](https://github.com/zenml-io/zenml/pull/4140))
 
 </details>
+
+[View full release on GitHub](https://github.com/zenml-io/zenml/releases/tag/0.91.1)
 
 ***
 ## 0.91.0 (2025-10-25)
@@ -171,6 +175,10 @@ See what's new and improved in version 0.91.0.
 ### Breaking Changes
 
 * Dropped Python 3.9 support - upgrade to Python 3.10+ ([#4053](https://github.com/zenml-io/zenml/pull/4053))
+
+[View full release on GitHub](https://github.com/zenml-io/zenml/releases/tag/0.91.0)
+
+***
 ## 0.90.0 (2025-10-02)
 
 See what's new and improved in version 0.90.0.
@@ -220,6 +228,10 @@ See what's new and improved in version 0.90.0.
 * Client-Server compatibility: Must upgrade both simultaneously
 * Run templates need to be recreated
 * Base package no longer includes local database dependencies - install `zenml[local]` if needed ([#3916](https://github.com/zenml-io/zenml/pull/3916))
+
+[View full release on GitHub](https://github.com/zenml-io/zenml/releases/tag/0.90.0)
+
+***
 ## 0.85.0 (2025-09-12)
 
 See what's new and improved in version 0.85.0.
@@ -270,6 +282,10 @@ See what's new and improved in version 0.85.0.
 * Docker package installer default switched from pip to uv ([#3935](https://github.com/zenml-io/zenml/pull/3935))
 * Log endpoint format changed ([#3845](https://github.com/zenml-io/zenml/pull/3845))
 
+[View full release on GitHub](https://github.com/zenml-io/zenml/releases/tag/0.85.0)
+
+***
+
 ## 0.84.3 (2025-08-27)
 
 See what's new and improved in version 0.84.3.
@@ -299,6 +315,10 @@ See what's new and improved in version 0.84.3.
 * Relaxed Click dependency version constraints ([#3905](https://github.com/zenml-io/zenml/pull/3905))
 
 </details>
+
+[View full release on GitHub](https://github.com/zenml-io/zenml/releases/tag/0.84.3)
+
+***
 
 ## 0.84.2 (2025-08-06)
 
@@ -330,6 +350,10 @@ See what's new and improved in version 0.84.2.
 * Better logging performance ([#3872](https://github.com/zenml-io/zenml/pull/3872))
 
 </details>
+
+[View full release on GitHub](https://github.com/zenml-io/zenml/releases/tag/0.84.2)
+
+***
 
 ## 0.84.1 (2025-07-30)
 
@@ -404,6 +428,10 @@ See what's new and improved in version 0.84.1.
 
 </details>
 
+[View full release on GitHub](https://github.com/zenml-io/zenml/releases/tag/0.84.1)
+
+***
+
 ## 0.84.0 (2025-07-11)
 
 See what's new and improved in version 0.84.0.
@@ -469,3 +497,7 @@ See what's new and improved in version 0.84.0.
 ### Breaking Changes
 
 * Kubernetes Orchestrator Compatibility: Client and orchestrator pod versions must match exactly
+
+[View full release on GitHub](https://github.com/zenml-io/zenml/releases/tag/0.84.0)
+
+***

--- a/scripts/update_changelog.py
+++ b/scripts/update_changelog.py
@@ -35,25 +35,25 @@ MAX_IMAGE_NUMBER = 49
 REPO_CONFIG: Dict[str, Dict[str, str]] = {
     "zenml-io/zenml": {
         "type": "oss",
-        "markdown_file": "gitbook-release-notes/oss.md",
+        "markdown_file": "gitbook-release-notes/server-sdk.md",
         "default_branch": "develop",
         "audience": "oss",
     },
     "zenml-io/zenml-dashboard": {
         "type": "oss",
-        "markdown_file": "gitbook-release-notes/oss.md",
+        "markdown_file": "gitbook-release-notes/server-sdk.md",
         "default_branch": "staging",
         "audience": "oss",
     },
     "zenml-io/zenml-cloud-ui": {
         "type": "pro",
-        "markdown_file": "gitbook-release-notes/pro.md",
+        "markdown_file": "gitbook-release-notes/pro-control-plane.md",
         "default_branch": "staging",
         "audience": "pro",
     },
     "zenml-io/zenml-cloud-api": {
         "type": "pro",
-        "markdown_file": "gitbook-release-notes/pro.md",
+        "markdown_file": "gitbook-release-notes/pro-control-plane.md",
         "default_branch": "develop",
         "audience": "pro",
     },
@@ -200,7 +200,10 @@ def llm_generate_changelog_copy(pr_title: str, pr_body: str, pr_url: str, repo_t
                     f"PR Body:\n{pr_body[:3500]}\n\n"
                     f"The audience is {audience}. Focus on what users can now do or benefit from.\n"
                     "Generate a concise title (max 60 characters, no PR number), a 1-3 sentence markdown-friendly "
-                    "description, and suggest appropriate labels."
+                    "description, and suggest appropriate labels. "
+                    "Feel free to include inline markdown links to well-known tools and libraries (e.g., "
+                    "[MLflow](https://github.com/mlflow/mlflow), [Transformers](https://github.com/huggingface/transformers)). "
+                    "Prefer linking to GitHub repos when available."
                 ),
             }
         ],
@@ -234,6 +237,15 @@ def llm_generate_markdown_section(
         if repo_type == "oss"
         else "Do not include PR links; keep the prose concise for Pro audiences."
     )
+    compatibility_instruction = (
+        "Append at the end:\n"
+        f"[View full release on GitHub]({release_url})\n\n"
+        "***"
+        if repo_type == "oss"
+        else "Append at the end:\n"
+        f"> **Compatibility:** Requires ZenML Server and SDK v0.85.0 or later.\n\n"
+        "***"
+    )
     response = anthropic_client.beta.messages.parse(
         model="claude-sonnet-4-5-20250929",
         betas=["structured-outputs-2025-11-13"],
@@ -258,7 +270,11 @@ def llm_generate_markdown_section(
                     "Use <details><summary>Fixed</summary>...</details> for bug fixes and "
                     "<details><summary>Improved</summary>...</details> for minor improvements when appropriate. "
                     f"{include_links_instruction} "
-                    "Highlight the top user-facing improvements first. End the section with *** on its own line."
+                    "Feel free to include inline markdown links to well-known tools and libraries (e.g., "
+                    "[MLflow](https://github.com/mlflow/mlflow), [Transformers](https://github.com/huggingface/transformers)). "
+                    "Prefer linking to GitHub repos when available. "
+                    "Highlight the top user-facing improvements first. End the section with *** on its own line. "
+                    f"{compatibility_instruction}"
                 ),
             }
         ],
@@ -292,7 +308,13 @@ def create_changelog_entry(pr: Dict[str, Any], source_repo: str, published_at: s
             "slug": slugify_title(pr["title"]),
             "title": pr["title"][:60],
             "description": "**[Needs review]** See PR for details.",
+            "feature_image_url": "",
+            "learn_more_url": "",
+            "docs_url": "",
             "published_at": published_at,
+            "highlight_until": "",
+            "should_highlight": False,
+            "video_url": "",
             "published": True,
             "audience": config["audience"],
             "labels": labels,
@@ -317,7 +339,13 @@ def create_changelog_entry(pr: Dict[str, Any], source_repo: str, published_at: s
             "slug": slugify_title(pr["title"]),
             "title": changelog_copy.title,
             "description": changelog_copy.description,
+            "feature_image_url": "",
+            "learn_more_url": "",
+            "docs_url": "",
             "published_at": published_at,
+            "highlight_until": "",
+            "should_highlight": False,
+            "video_url": "",
             "published": True,
             "audience": config["audience"],
             "labels": labels,


### PR DESCRIPTION
## Summary

- Update `REPO_CONFIG` to use renamed markdown files (`server-sdk.md`, `pro-control-plane.md`)
- Add SDK compatibility lines to all release entries (baseline v0.85.0)
- Add GitHub release links to OSS entries in `server-sdk.md`
- Include all schema properties with defaults in `changelog.json` entries for easier PR review
- Add inline markdown link guidance to LLM prompts (for linking to popular tools/repos)
- Fix `validate-changelog.yml` schema path (`changelog-items/` → `changelog_schema/`)
- Update `README.md` and `CLAUDE.md` file references

## Changes by File

| File | Changes |
|------|---------|
| `scripts/update_changelog.py` | REPO_CONFIG paths, LLM prompts, compatibility footer, schema defaults |
| `gitbook-release-notes/server-sdk.md` | Added compatibility + release links to 9 existing entries |
| `gitbook-release-notes/pro-control-plane.md` | Added compatibility lines to 17 existing entries |
| `.github/workflows/validate-changelog.yml` | Fixed schema path |
| `README.md` | Updated file references |
| `CLAUDE.md` | Updated file references |

## Test plan

- [ ] Verify workflow validation passes with corrected schema path
- [ ] Manually trigger a test release to verify new entries include all schema properties
- [ ] Confirm compatibility lines appear correctly in markdown output