### PR TITLE
Skip retries on Anthropic authentication errors

### DIFF
--- a/scripts/update_changelog.py
+++ b/scripts/update_changelog.py
@@ -21,13 +21,13 @@ from enum import Enum
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
-from anthropic import Anthropic, APIError, RateLimitError
+from anthropic import Anthropic, APIError, AuthenticationError, RateLimitError
 from github import Auth, Github
 from jsonschema import validate as jsonschema_validate
 from jsonschema.exceptions import ValidationError as JSONSchemaValidationError
 from pydantic import BaseModel, Field, ValidationError
 from slugify import slugify
-from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential
+from tenacity import retry, retry_if_exception_type, retry_if_not_exception_type, stop_after_attempt, wait_exponential
 
 IMAGE_STATE_FILE = Path(".image_state")
 MAX_IMAGE_NUMBER = 49
@@ -572,7 +572,7 @@ def slugify_title(title: str) -> str:
     reraise=True,
     stop=stop_after_attempt(5),
     wait=wait_exponential(multiplier=2, min=2, max=60),
-    retry=retry_if_exception_type((APIError, RateLimitError, ValidationError)),
+    retry=retry_if_exception_type((APIError, RateLimitError, ValidationError)) & retry_if_not_exception_type(AuthenticationError),
 )
 def llm_generate_changelog_copy(pr_title: str, pr_body: str, pr_url: str, repo_type: str) -> ChangelogCopy:
     # NOTE: This helper is primarily intended for ad-hoc or manual usage.
@@ -610,7 +610,7 @@ def llm_generate_changelog_copy(pr_title: str, pr_body: str, pr_url: str, repo_t
     reraise=True,
     stop=stop_after_attempt(5),
     wait=wait_exponential(multiplier=2, min=2, max=60),
-    retry=retry_if_exception_type((APIError, RateLimitError, ValidationError)),
+    retry=retry_if_exception_type((APIError, RateLimitError, ValidationError)) & retry_if_not_exception_type(AuthenticationError),
 )
 def llm_generate_grouped_changelog_entries(
     prs: List[Dict[str, Any]],
@@ -676,7 +676,7 @@ def llm_generate_grouped_changelog_entries(
     reraise=True,
     stop=stop_after_attempt(5),
     wait=wait_exponential(multiplier=2, min=2, max=60),
-    retry=retry_if_exception_type((APIError, RateLimitError, ValidationError)),
+    retry=retry_if_exception_type((APIError, RateLimitError, ValidationError)) & retry_if_not_exception_type(AuthenticationError),
 )
 def llm_generate_breaking_changes_bullets(
     breaking_prs: List[Dict[str, Any]],
@@ -803,7 +803,7 @@ def render_release_footer(source_repo: str, release_url: str) -> str:
     reraise=True,
     stop=stop_after_attempt(5),
     wait=wait_exponential(multiplier=2, min=2, max=60),
-    retry=retry_if_exception_type((APIError, RateLimitError, ValidationError)),
+    retry=retry_if_exception_type((APIError, RateLimitError, ValidationError)) & retry_if_not_exception_type(AuthenticationError),
 )
 def llm_generate_release_notes_body(
     prs: List[Dict[str, Any]],
@@ -871,7 +871,7 @@ def llm_generate_release_notes_body(
     reraise=True,
     stop=stop_after_attempt(5),
     wait=wait_exponential(multiplier=2, min=2, max=60),
-    retry=retry_if_exception_type((APIError, RateLimitError, ValidationError)),
+    retry=retry_if_exception_type((APIError, RateLimitError, ValidationError)) & retry_if_not_exception_type(AuthenticationError),
 )
 def llm_generate_markdown_section(
     prs: List[Dict[str, Any]],


### PR DESCRIPTION
## Summary

- `AuthenticationError` inherits from `APIError` in the Anthropic SDK, so tenacity was retrying 401 auth errors 5 times with exponential backoff (~60s wasted per run) before finally failing
- All process-release failures since March 26 were caused by an invalid `ANTHROPIC_API_KEY` secret (now re-added), but the retry behavior made each failure take longer than necessary
- Auth errors now fail immediately; rate limits and transient server errors still retry as before

## Test plan
- [ ] Verify `validate-changelog.yml` CI passes on this PR
- [ ] After merge, re-run the failed process-release workflows (0.13.7 through 0.94.2) to generate the missing changelogs