### PR TITLE
Prevent replaying consumed source release windows

### DIFF
--- a/.consumed_sources_state
+++ b/.consumed_sources_state
@@ -1,0 +1,45 @@
+{
+  "bootstrap_note": "Narrow manual seed from the PR75 duplicate-release-notes investigation only. This is not a complete historical bootstrap for all configured sources; future successful automation runs build the ledger forward. The seeded window is finalized, so late-labeled PRs inside it are intentionally ignored.",
+  "targets": {
+    "zenml-io/zenml-cloud-api::gitbook-release-notes/pro-control-plane.md": {
+      "consumed_prs": {
+        "zenml-io/zenml-cloud-ui#1317": {
+          "current_tag": "0.13.15",
+          "first_consumed_at": "2026-06-01T09:44:51.704139+00:00",
+          "first_consumed_by_release_tag": "0.13.15",
+          "number": 1317,
+          "origin": "manual-seed-pr75-investigation",
+          "previous_tag": "0.13.14",
+          "source_repo": "zenml-io/zenml-cloud-ui"
+        },
+        "zenml-io/zenml-cloud-ui#1318": {
+          "current_tag": "0.13.15",
+          "first_consumed_at": "2026-06-01T09:44:51.704139+00:00",
+          "first_consumed_by_release_tag": "0.13.15",
+          "number": 1318,
+          "origin": "manual-seed-pr75-investigation",
+          "previous_tag": "0.13.14",
+          "source_repo": "zenml-io/zenml-cloud-ui"
+        }
+      },
+      "consumed_windows": [
+        {
+          "consumed_at": "2026-06-01T09:44:51.704139+00:00",
+          "consumed_by_release_tag": "0.13.15",
+          "current_tag": "0.13.15",
+          "origin": "manual-seed-pr75-investigation",
+          "previous_tag": "0.13.14",
+          "pr_keys": [
+            "zenml-io/zenml-cloud-ui#1317",
+            "zenml-io/zenml-cloud-ui#1318"
+          ],
+          "source_repo": "zenml-io/zenml-cloud-ui"
+        }
+      ],
+      "markdown_file": "gitbook-release-notes/pro-control-plane.md",
+      "trigger_repo": "zenml-io/zenml-cloud-api"
+    }
+  },
+  "updated_at": "2026-06-02T00:00:00+00:00",
+  "version": 1
+}

--- a/.github/workflows/process-release.yml
+++ b/.github/workflows/process-release.yml
@@ -35,6 +35,7 @@ jobs:
       markdown_file: ${{ steps.extract_md.outputs.markdown_file }}
       breaking_changes: ${{ steps.extract_breaking.outputs.breaking_changes }}
       needs_attention: ${{ steps.extract_attention.outputs.needs_attention }}
+      source_windows: ${{ steps.extract_source_windows.outputs.source_windows }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -108,19 +109,39 @@ jobs:
             echo "EOF"
           } >> "$GITHUB_OUTPUT"
 
+      - name: Extract source windows
+        if: steps.check_changes.outputs.has_changes == 'true'
+        id: extract_source_windows
+        run: |
+          set -euo pipefail
+          if ! grep -q '^SOURCE_WINDOWS$' changelog_output.txt || ! grep -q '^END_SOURCE_WINDOWS$' changelog_output.txt; then
+            echo "ERROR: SOURCE_WINDOWS markers not found in changelog_output.txt" >&2
+            exit 1
+          fi
+          source_windows=$(awk '/^SOURCE_WINDOWS$/{flag=1;next}/^END_SOURCE_WINDOWS$/{flag=0}flag{print}' changelog_output.txt | tr -d '\r')
+          if [ -z "$source_windows" ]; then
+            echo "ERROR: SOURCE_WINDOWS block was empty" >&2
+            exit 1
+          fi
+          {
+            echo "source_windows<<EOF"
+            echo "${source_windows}"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
       - name: Create widget patch
         if: steps.check_changes.outputs.has_changes == 'true'
         run: |
           set -euo pipefail
           git diff --binary -- changelog.json .image_state > widget.patch
 
-      - name: Create gitbook patch
+      - name: Create release notes patch
         if: steps.check_changes.outputs.has_changes == 'true'
         env:
           MARKDOWN_FILE: ${{ steps.extract_md.outputs.markdown_file }}
         run: |
           set -euo pipefail
-          git diff --binary -- "$MARKDOWN_FILE" > gitbook.patch
+          git diff --binary -- "$MARKDOWN_FILE" .consumed_sources_state > release-notes.patch
 
       - name: Upload widget patch artifact
         if: steps.check_changes.outputs.has_changes == 'true'
@@ -130,12 +151,12 @@ jobs:
           path: widget.patch
           if-no-files-found: error
 
-      - name: Upload gitbook patch artifact
+      - name: Upload release notes patch artifact
         if: steps.check_changes.outputs.has_changes == 'true'
         uses: actions/upload-artifact@v4
         with:
-          name: gitbook-patch
-          path: gitbook.patch
+          name: release-notes-patch
+          path: release-notes.patch
           if-no-files-found: error
 
   pr-widget:
@@ -168,7 +189,7 @@ jobs:
         uses: peter-evans/create-pull-request@v6
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          commit-message: "chore: update changelog widget for ${{ env.SOURCE_REPO }}@${{ env.RELEASE_TAG }}"
+          commit-message: "Update changelog widget for ${{ env.SOURCE_REPO }}@${{ env.RELEASE_TAG }}"
           branch: changelog/${{ env.SOURCE_REPO_SLUG }}/${{ env.RELEASE_TAG }}
           base: main
           title: "Changelog widget: ${{ env.SOURCE_REPO }} ${{ env.RELEASE_TAG }}"
@@ -177,11 +198,19 @@ jobs:
             - **Repository:** ${{ env.SOURCE_REPO }}
             - **Tag:** ${{ env.RELEASE_TAG }}
 
+            This PR intentionally contains only dashboard widget state: `changelog.json` and `.image_state`. The release-notes PR for the same run owns the markdown file and `.consumed_sources_state` ledger.
+
+            ### Source windows
+
+            ```text
+            ${{ needs.generate.outputs.source_windows }}
+            ```
+
             ${{ needs.generate.outputs.needs_attention && '### ⚠️ PRs Needing Manual Review' || '' }}
             ${{ needs.generate.outputs.needs_attention }}
 
             **Please review:**
-            - [ ] LLM-generated grouped summaries (2-3 per release) are accurate and reflect the most important changes
+            - [ ] LLM-generated grouped summaries are accurate and reflect the most important changes
             - [ ] changelog.json entries have correct labels
             - [ ] Schema validation passes
             - [ ] Optional fields (`learn_more_url`, `docs_url`, `feature_image_url`) populated where applicable
@@ -191,7 +220,7 @@ jobs:
             changelog.json
             .image_state
 
-  pr-gitbook:
+  pr-release-notes:
     runs-on: ubuntu-latest
     needs: generate
     if: needs.generate.outputs.has_changes == 'true'
@@ -206,16 +235,16 @@ jobs:
           set -euo pipefail
           echo "SOURCE_REPO_SLUG=${SOURCE_REPO//\//-}" >> "$GITHUB_ENV"
 
-      - name: Download gitbook patch artifact
+      - name: Download release notes patch artifact
         uses: actions/download-artifact@v4
         with:
-          name: gitbook-patch
+          name: release-notes-patch
           path: .
 
-      - name: Apply gitbook patch
+      - name: Apply release notes patch
         run: |
           set -euo pipefail
-          git apply gitbook.patch
+          git apply release-notes.patch
 
       - name: Select reviewers and labels
         id: routing
@@ -236,11 +265,11 @@ jobs:
               ;;
           esac
 
-      - name: Create Pull Request (gitbook)
+      - name: Create Pull Request (release notes)
         uses: peter-evans/create-pull-request@v6
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          commit-message: "chore: update release notes for ${{ env.SOURCE_REPO }}@${{ env.RELEASE_TAG }}"
+          commit-message: "Update release notes for ${{ env.SOURCE_REPO }}@${{ env.RELEASE_TAG }}"
           branch: release-notes/${{ env.SOURCE_REPO_SLUG }}/${{ env.RELEASE_TAG }}
           base: main
           title: "Release notes: ${{ env.SOURCE_REPO }} ${{ env.RELEASE_TAG }}"
@@ -258,13 +287,23 @@ jobs:
             - **Tag:** ${{ env.RELEASE_TAG }}
             - **Markdown file:** `${{ needs.generate.outputs.markdown_file }}`
 
+            This PR owns the release-note markdown and `.consumed_sources_state`. Keeping the consumed-source ledger in this PR prevents a source window from being marked consumed unless the markdown that represents it is merged.
+
+            ### Source windows
+
+            ```text
+            ${{ needs.generate.outputs.source_windows }}
+            ```
+
             ${{ needs.generate.outputs.breaking_changes && '### ⚠️ Breaking Changes' || '' }}
             ${{ needs.generate.outputs.breaking_changes }}
 
             **Please review:**
             - [ ] Markdown formatting looks good in GitBook
             - [ ] Breaking changes are accurately described and migration guidance is clear (if applicable)
+            - [ ] Source windows make sense; skipped windows are finalized and will not be reopened for late-labeled PRs
           reviewers: ${{ steps.routing.outputs.reviewers }}
           labels: ${{ steps.routing.outputs.labels }}
           add-paths: |
             ${{ needs.generate.outputs.markdown_file }}
+            .consumed_sources_state

--- a/.gitignore
+++ b/.gitignore
@@ -216,3 +216,4 @@ design/
 
 # Workflow temp files
 changelog_output.txt
+prompt-exports/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,15 +13,18 @@ This repo is the canonical source of ZenML release metadata:
 ## Directory Structure
 
 - `changelog.json` — Array of announcements consumed by the dashboard.
-- `.image_state` — Persists rotating image index (1–49) for release note headers.
+- `.image_state` — Persists rotating image index (1–49) for release note headers only.
+- `.consumed_sources_state` — Dedicated ledger of consumed source release windows and PR keys, used to prevent bundled repo PRs from being summarized again on later trigger releases.
 - `gitbook-release-notes/`
   - `server-sdk.md` — OSS release notes (bundles content from zenml + zenml-dashboard).
-  - `pro-control-plane.md` — Pro release notes (bundles content from zenml-pro-api + zenml-cloud-ui).
+  - `pro-control-plane.md` — Pro release notes (bundles content from zenml-cloud-api + zenml-cloud-ui).
   - `README.md` — Notes for GitBook syncing.
 - `changelog_schema/`
   - `announcement-schema.json` — Validation schema for `changelog.json`.
   - `README.md` — Field documentation and examples.
-- `scripts/update_changelog.py` — Main automation script (fetch PRs, LLM summaries, update JSON/markdown, image rotation, validation).
+- `scripts/update_changelog.py` — High-level automation flow (LLM summaries, JSON/markdown writes, image rotation, validation).
+- `scripts/consumed_sources.py` — Consumed-window/PR ledger models, structured provenance, and read-time validation.
+- `scripts/source_windows.py` — Source-window resolution, replay prevention, and PR collection.
 - `scripts/validate_changelog.py` — Standalone schema validation (used by pre-commit hook).
 - `scripts/install-hooks.sh` — Installs git pre-commit hook for local validation.
 - `.github/workflows/`
@@ -42,18 +45,20 @@ This repo is the canonical source of ZenML release metadata:
   - Uses `uv run` to execute the script (deps declared inline via PEP 723).
   - Runs `scripts/update_changelog.py` with payload env vars (`SOURCE_REPO`, `RELEASE_TAG`, `RELEASE_URL`, `PUBLISHED_AT`, etc.).
   - Validates `changelog.json` against `changelog_schema/announcement-schema.json` via `cardinalby/schema-validator-action@v3`.
-  - Opens **two PRs**:
-    - **Widget PR** (`changelog/{repo_slug}/{tag}`): Updates `changelog.json` and `.image_state`. Reviewers: `htahir1,znegrin,strickvl`. Labels: `internal,x-squad`.
-    - **GitBook PR** (`release-notes/{repo_slug}/{tag}`): Updates the appropriate markdown file. Reviewers: `schustmi,bcdurak`. Labels: `core-squad,internal`.
+  - Opens **two PRs** with separate ownership:
+    - **Widget PR** (`changelog/{repo_slug}/{tag}`): Updates `changelog.json` and `.image_state` only. Reviewers: `htahir1,znegrin,strickvl`. Labels: `internal,x-squad`.
+    - **Release notes PR** (`release-notes/{repo_slug}/{tag}`): Updates the appropriate markdown file and `.consumed_sources_state`. Reviewers: `schustmi,bcdurak`. Labels: `core-squad,internal`.
 - Script: `scripts/update_changelog.py`
   - Uses `REPO_CONFIG` with nested `sources[]` arrays to define bundled repos per trigger.
-  - For each source repo: finds its previous tag, computes release window, fetches merged PRs with `release-notes` label.
+  - For each source repo: finds its previous tag, computes release window, and checks `.consumed_sources_state` before fetching PRs.
+  - Already-consumed windows are finalized windows: they are skipped before the LLM prompt is built and are not reopened for late-labeled PRs. Already-consumed repo-qualified PR keys are filtered as a second guardrail.
   - Aggregates and deduplicates PRs across all sources using `(repo, pr_number)` keys.
   - Generates 2-3 grouped changelog entries via Anthropic structured outputs (validated with Pydantic models).
   - Prepends entries to `changelog.json`, validates against `announcement-schema.json`.
   - Rotates header image using `.image_state` (cycles 1–49).
   - Generates markdown section (OSS links PRs; Pro omits PR links) and inserts after frontmatter in the appropriate file.
-  - Prints summary and exits; workflow handles PR creation.
+  - Updates `.consumed_sources_state` only after successful changelog and markdown updates, then prints source-window metadata for PR bodies.
+  - Prints summary and exits; workflow keeps `.consumed_sources_state` in the release-notes PR, so a source window is only marked consumed when the markdown that represents it is merged.
 
 ## Manually Adding Changelog Entries
 
@@ -128,7 +133,8 @@ The resulting URL will be: `https://public-flavor-logos.s3.eu-central-1.amazonaw
 
 - Keep `changelog.json` ordered newest-first; IDs must be unique and sequential.
 - If automation produces a PR conflict in `changelog.json`, rebase and re-run the workflow or fix ordering manually.
-- `.image_state` must stay committed so image rotation persists across runs.
+- `.image_state` must stay committed so image rotation persists across runs; keep it image-only.
+- `.consumed_sources_state` must stay committed so source windows/PRs are consumed once. Its current bootstrap is intentionally narrow, and recorded windows are finalized: late-labeled PRs inside them are ignored rather than replaying old release notes. If duplicate release notes appear, inspect this file rather than overloading `.image_state`.
 - For OSS markdown, include PR links; for Pro markdown, keep concise and omit PR links.
 - When adjusting prompts or schema, update `design/plan.md` for traceability.
 - Never commit secrets; use repo/org secrets for workflows.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@ Central hub for ZenML release metadata and release notes. This repo stores struc
 ```
 zenml-changelog/
 ├── changelog.json                  # Announcement entries consumed by the dashboard
-├── .image_state                    # Tracks rotating header image (1-49)
+├── .image_state                    # Tracks rotating header image (1-49) only
+├── .consumed_sources_state         # Tracks consumed source windows/PRs to prevent replay
 ├── gitbook-release-notes/
 │   ├── server-sdk.md               # OSS + dashboard release notes
 │   ├── pro-control-plane.md        # Pro/Cloud release notes
@@ -16,7 +17,9 @@ zenml-changelog/
 │   ├── announcement-schema.json    # JSON Schema for changelog.json
 │   └── README.md                   # Field documentation
 ├── scripts/
-│   └── update_changelog.py         # Automation script: PR fetch, LLM summaries, updates
+│   ├── update_changelog.py         # High-level automation flow and LLM/write steps
+│   ├── consumed_sources.py         # Consumed-window/PR ledger models and validation
+│   └── source_windows.py           # Source-window resolution and PR collection
 ├── .github/workflows/
 │   ├── process-release.yml         # repository_dispatch receiver, runs automation, opens PR
 │   └── validate-changelog.yml      # PR-time validation for changelog.json
@@ -31,29 +34,29 @@ flowchart TD
     A[Source repo release] -->|repository_dispatch<br/>event_type: release-published| B[process-release.yml]
     B --> C[Run update_changelog.py]
     C --> D[changelog.json + .image_state]
-    C --> E[gitbook-release-notes/*.md]
+    C --> E[gitbook-release-notes/*.md + .consumed_sources_state]
     D --> F[Schema validation]
     B --> G[Widget PR<br/>changelog/{repo}/{tag}]
-    B --> H[GitBook PR<br/>release-notes/{repo}/{tag}]
+    B --> H[Release notes PR<br/>release-notes/{repo}/{tag}]
 ```
 
-- Trigger: One of two trigger repos (`zenml-io/zenml` or `zenml-io/zenml-pro-api`) emits `repository_dispatch` (`release-published`).
-- Receiver: `.github/workflows/process-release.yml` installs deps, runs `scripts/update_changelog.py`, validates `changelog.json`, then opens two PRs with reviewers and labels based on trigger repo.
-- Script tasks: fetch `release-notes` PRs from all bundled source repos, aggregate and deduplicate, generate 2-3 grouped changelog entries (Anthropic structured outputs), rotate header image, update markdown, validate JSON.
+- Trigger: One of two trigger repos (`zenml-io/zenml` or `zenml-io/zenml-cloud-api`) emits `repository_dispatch` (`release-published`).
+- Receiver: `.github/workflows/process-release.yml` installs deps, runs `scripts/update_changelog.py`, validates `changelog.json`, then opens two PRs with reviewers and labels based on ownership: a widget PR for dashboard files and a release-notes PR for markdown plus the consumed-source ledger.
+- Script tasks: resolve each source repo's release window, skip windows/PRs already recorded in `.consumed_sources_state`, fetch `release-notes` PRs from the remaining bundled source windows, aggregate and deduplicate, generate 2-3 grouped changelog entries (Anthropic structured outputs), rotate header image, update markdown, validate JSON, and update the consumed-source ledger after successful output.
 - Breaking changes detection: PRs labeled `breaking-change` (and variants) are detected independently of `release-notes` and highlighted in a dedicated `### Breaking Changes` section near the top of release notes. Major version bumps always include this section (with a manual review prompt if no breaking PRs are found).
 
 ### PR Routing
 
-**Widget PR** (updates `changelog.json` and `.image_state`):
+**Widget PR** (updates `changelog.json` and `.image_state` only):
 - Reviewers: `htahir1`, `znegrin`, `strickvl`
 - Labels: `internal`, `x-squad`
 
-**GitBook PR** (updates release notes markdown):
+**Release notes PR** (updates release-note markdown and `.consumed_sources_state`):
 
 | Trigger Repository | Reviewers | Labels |
 | --- | --- | --- |
 | `zenml-io/zenml` (OSS) | schustmi, bcdurak | core-squad, internal |
-| `zenml-io/zenml-pro-api` (Pro) | htahir1, strickvl, znegrin | internal, x-squad |
+| `zenml-io/zenml-cloud-api` (Pro) | schustmi, bcdurak | core-squad, internal |
 
 ## Two-Path Architecture
 
@@ -62,9 +65,15 @@ The automation uses a **two-path flow** where each trigger aggregates PRs from m
 | Trigger Repository | Bundled Sources | Files Updated |
 | --- | --- | --- |
 | `zenml-io/zenml` (OSS) | zenml + zenml-dashboard | `changelog.json`, `gitbook-release-notes/server-sdk.md` |
-| `zenml-io/zenml-pro-api` (Pro) | zenml-pro-api + zenml-cloud-ui | `changelog.json`, `gitbook-release-notes/pro-control-plane.md` |
+| `zenml-io/zenml-cloud-api` (Pro) | zenml-cloud-api + zenml-cloud-ui | `changelog.json`, `gitbook-release-notes/pro-control-plane.md` |
 
-When a release is published on a trigger repo, the script automatically fetches PRs from all bundled source repos, aggregates them, and generates unified release notes.
+When a release is published on a trigger repo, the script automatically fetches PRs from all bundled source repos, aggregates them, and generates unified release notes. Bundled repos may have their own latest release tag, so the automation records each consumed source window (for example `zenml-cloud-ui 0.13.14 -> 0.13.15`) in `.consumed_sources_state`. On later trigger releases, an already-consumed window is skipped before any LLM prompt is built.
+
+Consumed windows are **finalized windows**: if a PR gains a `release-notes` or breaking-change label after its window was recorded, that window is not reopened. This avoids replaying already-published release notes.
+
+The committed bootstrap is intentionally narrow: it seeds only the confirmed PR75 Pro UI window from the investigation, not all historical OSS/Pro windows. Future successful automation runs build the ledger forward.
+
+Generated PR bodies include a `Source windows` block. Reviewers should check which windows were included, skipped, or filtered, especially when the bundled repo did not advance with the trigger repo. `.consumed_sources_state` belongs in the release-notes PR, not the widget PR, so a source window is only marked consumed when the markdown that represents it is merged.
 
 ## Manual vs Automated Entries
 

--- a/scripts/consumed_sources.py
+++ b/scripts/consumed_sources.py
@@ -1,0 +1,316 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+from pydantic import BaseModel, Field
+
+CONSUMED_SOURCE_STATE_FILE = Path(".consumed_sources_state")
+
+
+class ConsumedPR(BaseModel):
+    source_repo: str
+    number: int
+    first_consumed_by_release_tag: str
+    first_consumed_at: str
+    previous_tag: Optional[str] = None
+    current_tag: Optional[str] = None
+    # Legacy compatibility only. New writes use structured previous/current tags.
+    source_window: Optional[str] = None
+    origin: str = "automation"
+
+
+class ConsumedWindow(BaseModel):
+    source_repo: str
+    previous_tag: Optional[str] = None
+    current_tag: str
+    consumed_by_release_tag: str
+    consumed_at: str
+    pr_keys: List[str] = Field(default_factory=list)
+    origin: str = "automation"
+
+
+class ConsumedTargetState(BaseModel):
+    trigger_repo: str
+    markdown_file: str
+    consumed_windows: List[ConsumedWindow] = Field(default_factory=list)
+    consumed_prs: Dict[str, ConsumedPR] = Field(default_factory=dict)
+
+
+class ConsumedSourceState(BaseModel):
+    version: int = 1
+    updated_at: Optional[str] = None
+    # Narrow manual seed, not a complete historical bootstrap. Future successful
+    # automation runs build this ledger forward one finalized window at a time.
+    bootstrap_note: Optional[str] = None
+    targets: Dict[str, ConsumedTargetState] = Field(default_factory=dict)
+
+
+def _model_dump(model: BaseModel) -> Dict[str, Any]:
+    if hasattr(model, "model_dump"):
+        return model.model_dump(exclude_none=True)
+    return model.dict(exclude_none=True)  # type: ignore[attr-defined]
+
+
+def _validate_consumed_source_state(payload: Dict[str, Any]) -> ConsumedSourceState:
+    if hasattr(ConsumedSourceState, "model_validate"):
+        return ConsumedSourceState.model_validate(payload)
+    return ConsumedSourceState.parse_obj(payload)  # type: ignore[attr-defined]
+
+
+def target_state_key(trigger_repo: str, markdown_file: str) -> str:
+    return f"{trigger_repo}::{markdown_file}"
+
+
+def format_source_window(previous_tag: Optional[str], current_tag: str) -> str:
+    return f"{previous_tag or 'start'} -> {current_tag}"
+
+
+def make_pr_key(repo_name: str, number: int) -> str:
+    return f"{repo_name}#{number}"
+
+
+def parse_pr_key(key: str) -> Tuple[str, int]:
+    try:
+        repo_name, number_text = key.rsplit("#", 1)
+        return repo_name, int(number_text)
+    except ValueError as error:
+        raise RuntimeError(f"Invalid consumed PR key {key!r}; expected '<repo>#<number>'") from error
+
+
+def pr_key_from_dict(pr: Dict[str, Any]) -> str:
+    return make_pr_key(str(pr.get("repo", "")), int(pr["number"]))
+
+
+def _parse_legacy_source_window(source_window: Optional[str]) -> Tuple[Optional[str], Optional[str]]:
+    if not source_window or " -> " not in source_window:
+        return None, None
+    previous_tag, current_tag = source_window.split(" -> ", 1)
+    return (None if previous_tag == "start" else previous_tag), current_tag
+
+
+def _ensure_pr_window_tags(
+    consumed_pr: ConsumedPR,
+    previous_tag: Optional[str],
+    current_tag: str,
+) -> None:
+    if consumed_pr.current_tag is None:
+        legacy_previous, legacy_current = _parse_legacy_source_window(consumed_pr.source_window)
+        consumed_pr.previous_tag = legacy_previous
+        consumed_pr.current_tag = legacy_current
+
+    if consumed_pr.current_tag is None:
+        consumed_pr.previous_tag = previous_tag
+        consumed_pr.current_tag = current_tag
+
+    if consumed_pr.previous_tag != previous_tag or consumed_pr.current_tag != current_tag:
+        raise RuntimeError(
+            "Consumed PR window tags conflict with its containing consumed window: "
+            f"PR says {format_source_window(consumed_pr.previous_tag, consumed_pr.current_tag)}, "
+            f"window says {format_source_window(previous_tag, current_tag)}"
+        )
+
+    consumed_pr.source_window = None
+
+
+def reconcile_consumed_source_state(state: ConsumedSourceState) -> ConsumedSourceState:
+    """Normalize duplicated consumed-window/PR facts after reading state.
+
+    The canonical PR provenance is structured ``previous_tag``/``current_tag``.
+    ``source_window`` is accepted only as legacy input and is cleared on write.
+
+    A consumed window is finalized: once its ``source_repo`` + previous/current
+    tags are in the ledger, future runs skip that whole window before PR search.
+    Late-added labels inside a finalized window are intentionally ignored rather
+    than re-opening already-published release notes.
+    """
+    for target_key, target_state in state.targets.items():
+        for consumed_window in target_state.consumed_windows:
+            normalized_pr_keys: List[str] = []
+            for raw_key in consumed_window.pr_keys:
+                repo_name, number = parse_pr_key(raw_key)
+                normalized_key = make_pr_key(repo_name, number)
+                if repo_name != consumed_window.source_repo:
+                    raise RuntimeError(
+                        f"Consumed state target {target_key} has window "
+                        f"{format_source_window(consumed_window.previous_tag, consumed_window.current_tag)} "
+                        f"for {consumed_window.source_repo}, but window PR key {raw_key!r} "
+                        f"belongs to {repo_name}"
+                    )
+
+                existing = target_state.consumed_prs.get(normalized_key)
+                if existing is None:
+                    target_state.consumed_prs[normalized_key] = ConsumedPR(
+                        source_repo=repo_name,
+                        number=number,
+                        first_consumed_by_release_tag=consumed_window.consumed_by_release_tag,
+                        first_consumed_at=consumed_window.consumed_at,
+                        previous_tag=consumed_window.previous_tag,
+                        current_tag=consumed_window.current_tag,
+                        origin=consumed_window.origin,
+                    )
+                else:
+                    _ensure_pr_window_tags(
+                        existing,
+                        previous_tag=consumed_window.previous_tag,
+                        current_tag=consumed_window.current_tag,
+                    )
+                    if existing.source_repo != repo_name or existing.number != number:
+                        raise RuntimeError(
+                            f"Consumed state target {target_key} has conflicting facts for "
+                            f"{normalized_key}: record says {existing.source_repo}#{existing.number}"
+                        )
+                normalized_pr_keys.append(normalized_key)
+
+            consumed_window.pr_keys = sorted(set(normalized_pr_keys))
+
+        for key, consumed_pr in target_state.consumed_prs.items():
+            repo_name, number = parse_pr_key(key)
+            if consumed_pr.current_tag is None:
+                legacy_previous, legacy_current = _parse_legacy_source_window(consumed_pr.source_window)
+                consumed_pr.previous_tag = legacy_previous
+                consumed_pr.current_tag = legacy_current
+            if consumed_pr.current_tag is None:
+                raise RuntimeError(
+                    f"Consumed state target {target_key} has standalone consumed_prs key {key!r} "
+                    "without structured previous_tag/current_tag"
+                )
+            if consumed_pr.source_repo != repo_name or consumed_pr.number != number:
+                raise RuntimeError(
+                    f"Consumed state target {target_key} has consumed_prs key {key!r} "
+                    f"but record says {consumed_pr.source_repo}#{consumed_pr.number}"
+                )
+            consumed_pr.source_window = None
+
+    return state
+
+
+def read_consumed_source_state(path: Path = CONSUMED_SOURCE_STATE_FILE) -> ConsumedSourceState:
+    if not path.exists():
+        return ConsumedSourceState()
+
+    raw = path.read_text().strip()
+    if not raw:
+        return ConsumedSourceState()
+
+    try:
+        loaded = json.loads(raw)
+    except json.JSONDecodeError as error:
+        raise RuntimeError(f"Invalid JSON in consumed source state file {path}: {error}") from error
+
+    if not isinstance(loaded, dict):
+        raise RuntimeError(f"Consumed source state file {path} must contain a JSON object")
+
+    try:
+        return reconcile_consumed_source_state(_validate_consumed_source_state(loaded))
+    except Exception as error:
+        raise RuntimeError(f"Invalid consumed source state file {path}: {error}") from error
+
+
+def write_consumed_source_state(
+    state: ConsumedSourceState,
+    path: Path = CONSUMED_SOURCE_STATE_FILE,
+) -> None:
+    state.updated_at = datetime.now(timezone.utc).isoformat()
+    path.write_text(json.dumps(_model_dump(state), indent=2, sort_keys=True) + "\n")
+
+
+def get_consumed_target_state(
+    state: ConsumedSourceState,
+    trigger_repo: str,
+    markdown_file: str,
+) -> Optional[ConsumedTargetState]:
+    return state.targets.get(target_state_key(trigger_repo, markdown_file))
+
+
+def get_or_create_consumed_target_state(
+    state: ConsumedSourceState,
+    trigger_repo: str,
+    markdown_file: str,
+) -> ConsumedTargetState:
+    key = target_state_key(trigger_repo, markdown_file)
+    if key not in state.targets:
+        state.targets[key] = ConsumedTargetState(
+            trigger_repo=trigger_repo,
+            markdown_file=markdown_file,
+        )
+    return state.targets[key]
+
+
+def find_consumed_window(
+    target_state: Optional[ConsumedTargetState],
+    source_repo: str,
+    previous_tag: Optional[str],
+    current_tag: str,
+) -> Optional[ConsumedWindow]:
+    if target_state is None:
+        return None
+    for consumed_window in target_state.consumed_windows:
+        if (
+            consumed_window.source_repo == source_repo
+            and consumed_window.previous_tag == previous_tag
+            and consumed_window.current_tag == current_tag
+        ):
+            return consumed_window
+    return None
+
+
+def is_pr_consumed(target_state: Optional[ConsumedTargetState], key: str) -> bool:
+    return bool(target_state and key in target_state.consumed_prs)
+
+
+def mark_consumed_after_success(
+    state: ConsumedSourceState,
+    trigger_repo: str,
+    markdown_file: str,
+    trigger_release_tag: str,
+    collection: Any,
+    now: datetime,
+) -> ConsumedSourceState:
+    target_state = get_or_create_consumed_target_state(state, trigger_repo, markdown_file)
+    consumed_at = now.astimezone(timezone.utc).isoformat()
+
+    for source_collection in collection.included_windows:
+        window = source_collection.window
+        window_pr_keys = sorted(
+            {
+                pr_key_from_dict(pr)
+                for pr in source_collection.release_notes_prs + source_collection.breaking_prs
+            }
+        )
+
+        if find_consumed_window(
+            target_state=target_state,
+            source_repo=window.source_repo,
+            previous_tag=window.previous_tag,
+            current_tag=window.current_tag,
+        ) is None:
+            target_state.consumed_windows.append(
+                ConsumedWindow(
+                    source_repo=window.source_repo,
+                    previous_tag=window.previous_tag,
+                    current_tag=window.current_tag,
+                    consumed_by_release_tag=trigger_release_tag,
+                    consumed_at=consumed_at,
+                    pr_keys=window_pr_keys,
+                )
+            )
+
+        for key in window_pr_keys:
+            if key in target_state.consumed_prs:
+                continue
+            repo_name, number = parse_pr_key(key)
+            target_state.consumed_prs[key] = ConsumedPR(
+                source_repo=repo_name,
+                number=number,
+                first_consumed_by_release_tag=trigger_release_tag,
+                first_consumed_at=consumed_at,
+                previous_tag=window.previous_tag,
+                current_tag=window.current_tag,
+            )
+
+    state.targets[target_state_key(trigger_repo, markdown_file)] = target_state
+    state.updated_at = consumed_at
+    return state

--- a/scripts/source_windows.py
+++ b/scripts/source_windows.py
@@ -1,0 +1,295 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Callable, Dict, List, Literal, Optional, Tuple
+
+from github import Github
+from pydantic import BaseModel, Field
+
+try:
+    from scripts.consumed_sources import (
+        ConsumedSourceState,
+        ConsumedTargetState,
+        find_consumed_window,
+        format_source_window,
+        get_consumed_target_state,
+        is_pr_consumed,
+        pr_key_from_dict,
+    )
+except ModuleNotFoundError:  # pragma: no cover - direct `uv run scripts/update_changelog.py`
+    from consumed_sources import (  # type: ignore[no-redef]
+        ConsumedSourceState,
+        ConsumedTargetState,
+        find_consumed_window,
+        format_source_window,
+        get_consumed_target_state,
+        is_pr_consumed,
+        pr_key_from_dict,
+    )
+
+SOURCE_WINDOWS_START_MARKER = "SOURCE_WINDOWS"
+SOURCE_WINDOWS_END_MARKER = "END_SOURCE_WINDOWS"
+SKIP_REASON_NO_RELEASES_FOUND = "no_releases_found"
+SKIP_REASON_ALREADY_CONSUMED_WINDOW = "already_consumed_window"
+SkipReason = Literal["no_releases_found", "already_consumed_window"]
+
+FindLatestReleaseTag = Callable[[Github, str], Optional[str]]
+FindPreviousTag = Callable[[Github, str, str], Optional[str]]
+GetReleaseWindow = Callable[[Github, str, Optional[str], str], Tuple[datetime, datetime]]
+SearchMergedPRs = Callable[
+    [Github, str, str, datetime, datetime, Optional[str]],
+    List[Dict[str, Any]],
+]
+DedupePRs = Callable[[List[Dict[str, Any]]], List[Dict[str, Any]]]
+
+
+class SourceReleaseWindow(BaseModel):
+    source_repo: str
+    base_branch: str
+    previous_tag: Optional[str] = None
+    current_tag: str
+    since_date: datetime
+    until_date: datetime
+    is_primary: bool = False
+
+
+class SkippedSourceWindow(BaseModel):
+    source_repo: str
+    previous_tag: Optional[str] = None
+    current_tag: Optional[str] = None
+    reason: SkipReason
+    consumed_by_release_tag: Optional[str] = None
+
+
+class SourceWindowCollection(BaseModel):
+    window: SourceReleaseWindow
+    release_notes_prs: List[Dict[str, Any]] = Field(default_factory=list)
+    breaking_prs: List[Dict[str, Any]] = Field(default_factory=list)
+    filtered_pr_keys: List[str] = Field(default_factory=list)
+
+
+class MultiSourceCollectionResult(BaseModel):
+    included_windows: List[SourceWindowCollection] = Field(default_factory=list)
+    skipped_windows: List[SkippedSourceWindow] = Field(default_factory=list)
+    release_notes_prs: List[Dict[str, Any]] = Field(default_factory=list)
+    breaking_prs: List[Dict[str, Any]] = Field(default_factory=list)
+
+
+def _filter_consumed_prs(
+    prs: List[Dict[str, Any]],
+    target_state: Optional[ConsumedTargetState],
+) -> Tuple[List[Dict[str, Any]], List[str]]:
+    kept: List[Dict[str, Any]] = []
+    filtered_keys: List[str] = []
+    for pr in prs:
+        key = pr_key_from_dict(pr)
+        if is_pr_consumed(target_state, key):
+            filtered_keys.append(key)
+            continue
+        kept.append(pr)
+    return kept, filtered_keys
+
+
+def resolve_source_window(
+    gh: Github,
+    source: Dict[str, Any],
+    primary_source: str,
+    trigger_release_tag: str,
+    find_latest_release_tag: FindLatestReleaseTag,
+    find_previous_tag: FindPreviousTag,
+    get_release_window: GetReleaseWindow,
+) -> Tuple[Optional[SourceReleaseWindow], Optional[SkippedSourceWindow]]:
+    source_repo = source["repo"]
+    is_primary = source_repo == primary_source
+
+    if is_primary:
+        current_tag = trigger_release_tag
+    else:
+        current_tag = find_latest_release_tag(gh, source_repo)
+        if current_tag is None:
+            return None, SkippedSourceWindow(
+                source_repo=source_repo,
+                reason=SKIP_REASON_NO_RELEASES_FOUND,
+            )
+
+    previous_tag = find_previous_tag(gh, source_repo, current_tag)
+    since_date, until_date = get_release_window(
+        gh,
+        source_repo,
+        previous_tag,
+        current_tag,
+    )
+    return SourceReleaseWindow(
+        source_repo=source_repo,
+        base_branch=source.get("default_branch", "main"),
+        previous_tag=previous_tag,
+        current_tag=current_tag,
+        since_date=since_date,
+        until_date=until_date,
+        is_primary=is_primary,
+    ), None
+
+
+def collect_window_prs(
+    gh: Github,
+    window: SourceReleaseWindow,
+    target_state: Optional[ConsumedTargetState],
+    breaking_change_labels: List[str],
+    search_merged_prs: SearchMergedPRs,
+    dedupe_prs_by_number: DedupePRs,
+) -> SourceWindowCollection:
+    release_note_prs = search_merged_prs(
+        gh,
+        window.source_repo,
+        window.base_branch,
+        window.since_date,
+        window.until_date,
+        "release-notes",
+    )
+    release_note_prs, release_note_filtered = _filter_consumed_prs(
+        release_note_prs,
+        target_state,
+    )
+
+    breaking_prs_for_window: List[Dict[str, Any]] = []
+    breaking_filtered: List[str] = []
+    for breaking_label in breaking_change_labels:
+        source_breaking_prs = search_merged_prs(
+            gh,
+            window.source_repo,
+            window.base_branch,
+            window.since_date,
+            window.until_date,
+            breaking_label,
+        )
+        filtered_source_breaking_prs, filtered_keys = _filter_consumed_prs(
+            source_breaking_prs,
+            target_state,
+        )
+        breaking_prs_for_window.extend(filtered_source_breaking_prs)
+        breaking_filtered.extend(filtered_keys)
+
+    return SourceWindowCollection(
+        window=window,
+        release_notes_prs=dedupe_prs_by_number(release_note_prs),
+        breaking_prs=dedupe_prs_by_number(breaking_prs_for_window),
+        filtered_pr_keys=sorted(set(release_note_filtered + breaking_filtered)),
+    )
+
+
+def collect_multi_source_prs(
+    gh: Github,
+    trigger_repo: str,
+    trigger_release_tag: str,
+    consumed_state: ConsumedSourceState,
+    repo_config: Dict[str, Dict[str, Any]],
+    breaking_change_labels: List[str],
+    find_latest_release_tag: FindLatestReleaseTag,
+    find_previous_tag: FindPreviousTag,
+    get_release_window: GetReleaseWindow,
+    search_merged_prs: SearchMergedPRs,
+    dedupe_prs_by_number: DedupePRs,
+) -> MultiSourceCollectionResult:
+    """Collect release-note and breaking-change PRs through one source-window path.
+
+    Primary sources use the triggering release tag. Bundled sources keep the useful
+    existing behavior of using their latest release, but each resolved source window
+    is checked against the dedicated consumed-source ledger before PR search.
+
+    A matched consumed window is finalized: it is skipped completely. This means
+    PRs that gain a release-note/breaking label after the window was recorded are
+    intentionally ignored instead of reopening already-published release notes.
+    """
+    config = repo_config.get(trigger_repo)
+    if config is None:
+        raise RuntimeError(f"Repository {trigger_repo} is not configured for changelog updates")
+
+    sources = config.get("sources", [])
+    if not sources:
+        return MultiSourceCollectionResult()
+
+    markdown_file = config["markdown_file"]
+    target_state = get_consumed_target_state(
+        state=consumed_state,
+        trigger_repo=trigger_repo,
+        markdown_file=markdown_file,
+    )
+    primary_source = sources[0]["repo"]
+
+    result = MultiSourceCollectionResult()
+    all_release_note_prs: List[Dict[str, Any]] = []
+    all_breaking_prs: List[Dict[str, Any]] = []
+
+    for source in sources:
+        window, skipped_window = resolve_source_window(
+            gh=gh,
+            source=source,
+            primary_source=primary_source,
+            trigger_release_tag=trigger_release_tag,
+            find_latest_release_tag=find_latest_release_tag,
+            find_previous_tag=find_previous_tag,
+            get_release_window=get_release_window,
+        )
+        if skipped_window is not None:
+            result.skipped_windows.append(skipped_window)
+            continue
+        if window is None:
+            continue
+
+        consumed_window = find_consumed_window(
+            target_state=target_state,
+            source_repo=window.source_repo,
+            previous_tag=window.previous_tag,
+            current_tag=window.current_tag,
+        )
+        if consumed_window is not None:
+            result.skipped_windows.append(
+                SkippedSourceWindow(
+                    source_repo=window.source_repo,
+                    previous_tag=window.previous_tag,
+                    current_tag=window.current_tag,
+                    reason=SKIP_REASON_ALREADY_CONSUMED_WINDOW,
+                    consumed_by_release_tag=consumed_window.consumed_by_release_tag,
+                )
+            )
+            continue
+
+        source_collection = collect_window_prs(
+            gh=gh,
+            window=window,
+            target_state=target_state,
+            breaking_change_labels=breaking_change_labels,
+            search_merged_prs=search_merged_prs,
+            dedupe_prs_by_number=dedupe_prs_by_number,
+        )
+        result.included_windows.append(source_collection)
+        all_release_note_prs.extend(source_collection.release_notes_prs)
+        all_breaking_prs.extend(source_collection.breaking_prs)
+
+    result.release_notes_prs = dedupe_prs_by_number(all_release_note_prs)
+    result.breaking_prs = dedupe_prs_by_number(all_breaking_prs)
+    return result
+
+
+def format_source_window_report(collection: MultiSourceCollectionResult) -> str:
+    lines = [SOURCE_WINDOWS_START_MARKER]
+    for source_collection in collection.included_windows:
+        window = source_collection.window
+        lines.append(
+            "included "
+            f"{window.source_repo} "
+            f"{format_source_window(window.previous_tag, window.current_tag)} "
+            f"release_notes={len(source_collection.release_notes_prs)} "
+            f"breaking={len(source_collection.breaking_prs)} "
+            f"filtered={len(source_collection.filtered_pr_keys)}"
+        )
+    for skipped_window in collection.skipped_windows:
+        lines.append(
+            "skipped "
+            f"{skipped_window.source_repo} "
+            f"{format_source_window(skipped_window.previous_tag, skipped_window.current_tag or '<none>')} "
+            f"reason={skipped_window.reason} "
+            f"consumed_by={skipped_window.consumed_by_release_tag or '<none>'}"
+        )
+    lines.append(SOURCE_WINDOWS_END_MARKER)
+    return "\n".join(lines)

--- a/scripts/update_changelog.py
+++ b/scripts/update_changelog.py
@@ -29,6 +29,49 @@ from pydantic import BaseModel, Field, ValidationError
 from slugify import slugify
 from tenacity import retry, retry_if_exception_type, retry_if_not_exception_type, stop_after_attempt, wait_exponential
 
+try:
+    from scripts.consumed_sources import (
+        CONSUMED_SOURCE_STATE_FILE,
+        ConsumedPR,
+        ConsumedSourceState,
+        ConsumedTargetState,
+        ConsumedWindow,
+        format_source_window,
+        mark_consumed_after_success,
+        read_consumed_source_state,
+        target_state_key,
+        write_consumed_source_state,
+    )
+    from scripts.source_windows import (
+        SKIP_REASON_ALREADY_CONSUMED_WINDOW,
+        SOURCE_WINDOWS_END_MARKER,
+        SOURCE_WINDOWS_START_MARKER,
+        MultiSourceCollectionResult,
+        collect_multi_source_prs as _collect_multi_source_prs,
+        format_source_window_report,
+    )
+except ModuleNotFoundError:  # pragma: no cover - direct `uv run scripts/update_changelog.py`
+    from consumed_sources import (  # type: ignore[no-redef]
+        CONSUMED_SOURCE_STATE_FILE,
+        ConsumedPR,
+        ConsumedSourceState,
+        ConsumedTargetState,
+        ConsumedWindow,
+        format_source_window,
+        mark_consumed_after_success,
+        read_consumed_source_state,
+        target_state_key,
+        write_consumed_source_state,
+    )
+    from source_windows import (  # type: ignore[no-redef]
+        SKIP_REASON_ALREADY_CONSUMED_WINDOW,
+        SOURCE_WINDOWS_END_MARKER,
+        SOURCE_WINDOWS_START_MARKER,
+        MultiSourceCollectionResult,
+        collect_multi_source_prs as _collect_multi_source_prs,
+        format_source_window_report,
+    )
+
 IMAGE_STATE_FILE = Path(".image_state")
 MAX_IMAGE_NUMBER = 49
 
@@ -187,6 +230,7 @@ class ImageState(BaseModel):
     last_markdown_file: Optional[str] = None
     updated_at: Optional[str] = None
 
+
 class MarkdownSection(BaseModel):
     content: str = Field(..., description="Complete markdown section for the release notes")
 
@@ -221,9 +265,13 @@ def read_image_state(path: Path = IMAGE_STATE_FILE) -> ImageState:
     except ValueError:
         return ImageState()
 
+def _model_dump(model: BaseModel) -> Dict[str, Any]:
+    return model.model_dump() if hasattr(model, "model_dump") else model.dict()  # type: ignore[attr-defined]
+
+
 def write_image_state(state: ImageState, path: Path = IMAGE_STATE_FILE) -> None:
-    payload = state.model_dump() if hasattr(state, "model_dump") else state.dict()  # type: ignore[attr-defined]
-    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+    path.write_text(json.dumps(_model_dump(state), indent=2, sort_keys=True) + "\n")
+
 
 def infer_latest_image_from_markdown(md_path: Path) -> Optional[int]:
     try:
@@ -471,108 +519,25 @@ def is_major_bump(previous_tag: Optional[str], current_tag: str) -> bool:
         return False
     return current[0] > previous[0]
 
-def get_multi_source_release_prs(
+def collect_multi_source_prs(
     gh: Github,
     trigger_repo: str,
     trigger_release_tag: str,
-) -> List[Dict[str, Any]]:
-    """Collect release-notes PRs for a trigger repo across its configured sources."""
-    config = REPO_CONFIG.get(trigger_repo)
-    if config is None:
-        raise RuntimeError(f"Repository {trigger_repo} is not configured for changelog updates")
-
-    sources = config.get("sources", [])
-    if not sources:
-        return []
-
-    # Primary source is the trigger repo itself (first in list)
-    primary_source = sources[0]["repo"]
-
-    all_prs: List[Dict[str, Any]] = []
-    for source in sources:
-        source_repo = source["repo"]
-
-        if source_repo == primary_source:
-            # Trigger repo: use the provided trigger_release_tag
-            current_tag = trigger_release_tag
-        else:
-            # Bundled repo: find its latest release (guaranteed to exist per team agreements)
-            current_tag = find_latest_release_tag(gh, source_repo)
-            if current_tag is None:
-                print(f"Warning: No releases found for bundled repo {source_repo}, skipping")
-                continue
-
-        previous_tag = find_previous_tag(gh, source_repo, current_tag)
-        since_date, until_date = get_release_window(
-            gh=gh,
-            repo_name=source_repo,
-            since_tag=previous_tag,
-            until_tag=current_tag,
-        )
-        source_prs = search_merged_prs(
-            gh=gh,
-            repo_name=source_repo,
-            base_branch=source.get("default_branch", "main"),
-            since_date=since_date,
-            until_date=until_date,
-            label="release-notes",
-        )
-        print(f"  {source_repo}: {len(source_prs)} PRs ({previous_tag or 'start'} → {current_tag})")
-        all_prs.extend(source_prs)
-
-    return dedupe_prs_by_number(all_prs)
-
-
-def get_multi_source_breaking_prs(
-    gh: Github,
-    trigger_repo: str,
-    trigger_release_tag: str,
-) -> List[Dict[str, Any]]:
-    """Collect breaking-change PRs for a trigger repo across its configured sources."""
-    config = REPO_CONFIG.get(trigger_repo)
-    if config is None:
-        raise RuntimeError(f"Repository {trigger_repo} is not configured for changelog updates")
-
-    sources = config.get("sources", [])
-    if not sources:
-        return []
-
-    # Primary source is the trigger repo itself (first in list)
-    primary_source = sources[0]["repo"]
-
-    all_prs: List[Dict[str, Any]] = []
-    for source in sources:
-        source_repo = source["repo"]
-
-        if source_repo == primary_source:
-            # Trigger repo: use the provided trigger_release_tag
-            current_tag = trigger_release_tag
-        else:
-            # Bundled repo: find its latest release (guaranteed to exist per team agreements)
-            current_tag = find_latest_release_tag(gh, source_repo)
-            if current_tag is None:
-                print(f"Warning: No releases found for bundled repo {source_repo}, skipping")
-                continue
-
-        previous_tag = find_previous_tag(gh, source_repo, current_tag)
-        since_date, until_date = get_release_window(
-            gh=gh,
-            repo_name=source_repo,
-            since_tag=previous_tag,
-            until_tag=current_tag,
-        )
-        for breaking_label in BREAKING_CHANGE_LABELS:
-            source_prs = search_merged_prs(
-                gh=gh,
-                repo_name=source_repo,
-                base_branch=source.get("default_branch", "main"),
-                since_date=since_date,
-                until_date=until_date,
-                label=breaking_label,
-            )
-            all_prs.extend(source_prs)
-
-    return dedupe_prs_by_number(all_prs)
+    consumed_state: ConsumedSourceState,
+) -> MultiSourceCollectionResult:
+    return _collect_multi_source_prs(
+        gh=gh,
+        trigger_repo=trigger_repo,
+        trigger_release_tag=trigger_release_tag,
+        consumed_state=consumed_state,
+        repo_config=REPO_CONFIG,
+        breaking_change_labels=BREAKING_CHANGE_LABELS,
+        find_latest_release_tag=find_latest_release_tag,
+        find_previous_tag=find_previous_tag,
+        get_release_window=get_release_window,
+        search_merged_prs=search_merged_prs,
+        dedupe_prs_by_number=dedupe_prs_by_number,
+    )
 
 
 def slugify_title(title: str) -> str:
@@ -1270,10 +1235,19 @@ def main() -> None:
         f"(primary previous: {primary_previous_tag or 'first release'})"
     )
 
-    release_notes_prs = get_multi_source_release_prs(gh, source_repo, env["RELEASE_TAG"])
+    consumed_state = read_consumed_source_state()
+    collection = collect_multi_source_prs(
+        gh=gh,
+        trigger_repo=source_repo,
+        trigger_release_tag=env["RELEASE_TAG"],
+        consumed_state=consumed_state,
+    )
+    print(format_source_window_report(collection))
+
+    release_notes_prs = collection.release_notes_prs
     print(f"Found {len(release_notes_prs)} PRs with release-notes label across all sources")
 
-    breaking_prs = get_multi_source_breaking_prs(gh, source_repo, env["RELEASE_TAG"])
+    breaking_prs = collection.breaking_prs
     print(f"Found {len(breaking_prs)} PRs with breaking-change labels across all sources")
 
     major_bump = is_major_bump(primary_previous_tag, env["RELEASE_TAG"])
@@ -1345,9 +1319,21 @@ def main() -> None:
     md_section = header + breaking_section + body + "\n\n" + footer
 
     update_markdown_file(Path(markdown_file), md_section)
+
+    consumed_state = mark_consumed_after_success(
+        state=consumed_state,
+        trigger_repo=source_repo,
+        markdown_file=markdown_file,
+        trigger_release_tag=env["RELEASE_TAG"],
+        collection=collection,
+        now=datetime.now(timezone.utc),
+    )
+    write_consumed_source_state(consumed_state)
+
     print(
-        f"Updated changelog.json (+{len(new_entries)} entries) and "
-        f"{config['markdown_file']} (image {image_number})."
+        f"Updated changelog.json (+{len(new_entries)} entries), "
+        f"{config['markdown_file']} (image {image_number}), and "
+        f"{CONSUMED_SOURCE_STATE_FILE}."
     )
 
     if breaking_section.strip():

--- a/tests/test_consumed_source_windows.py
+++ b/tests/test_consumed_source_windows.py
@@ -1,0 +1,412 @@
+from __future__ import annotations
+
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from scripts import update_changelog as uc
+
+
+def make_pr(
+    number: int,
+    repo: str,
+    labels: list[str] | None = None,
+) -> dict[str, Any]:
+    return {
+        "number": number,
+        "title": f"PR {number}",
+        "labels": labels or [],
+        "url": f"https://github.com/{repo}/pull/{number}",
+        "body": f"Body for PR {number}",
+        "repo": repo,
+        "merged_at": datetime(2026, 6, 1, tzinfo=timezone.utc),
+    }
+
+
+def pro_target_state(
+    consumed_windows: list[uc.ConsumedWindow] | None = None,
+    consumed_prs: dict[str, uc.ConsumedPR] | None = None,
+) -> uc.ConsumedSourceState:
+    markdown_file = "gitbook-release-notes/pro-control-plane.md"
+    key = uc.target_state_key("zenml-io/zenml-cloud-api", markdown_file)
+    return uc.ConsumedSourceState(
+        targets={
+            key: uc.ConsumedTargetState(
+                trigger_repo="zenml-io/zenml-cloud-api",
+                markdown_file=markdown_file,
+                consumed_windows=consumed_windows or [],
+                consumed_prs=consumed_prs or {},
+            )
+        }
+    )
+
+
+def consumed_ui_01314_to_01315_state() -> uc.ConsumedSourceState:
+    consumed_at = "2026-06-01T09:44:51.704139+00:00"
+    return pro_target_state(
+        consumed_windows=[
+            uc.ConsumedWindow(
+                source_repo="zenml-io/zenml-cloud-ui",
+                previous_tag="0.13.14",
+                current_tag="0.13.15",
+                consumed_by_release_tag="0.13.15",
+                consumed_at=consumed_at,
+                pr_keys=[
+                    "zenml-io/zenml-cloud-ui#1317",
+                    "zenml-io/zenml-cloud-ui#1318",
+                ],
+                origin="manual-seed-pr75-investigation",
+            )
+        ],
+        consumed_prs={
+            "zenml-io/zenml-cloud-ui#1317": uc.ConsumedPR(
+                source_repo="zenml-io/zenml-cloud-ui",
+                number=1317,
+                first_consumed_by_release_tag="0.13.15",
+                first_consumed_at=consumed_at,
+                previous_tag="0.13.14",
+                current_tag="0.13.15",
+                origin="manual-seed-pr75-investigation",
+            ),
+            "zenml-io/zenml-cloud-ui#1318": uc.ConsumedPR(
+                source_repo="zenml-io/zenml-cloud-ui",
+                number=1318,
+                first_consumed_by_release_tag="0.13.15",
+                first_consumed_at=consumed_at,
+                previous_tag="0.13.14",
+                current_tag="0.13.15",
+                origin="manual-seed-pr75-investigation",
+            ),
+        },
+    )
+
+
+def patch_release_window_resolution(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    ui_current_tag: str = "0.13.15",
+    ui_previous_tag: str = "0.13.14",
+) -> list[tuple[str, str | None]]:
+    searches: list[tuple[str, str | None]] = []
+
+    def fake_find_latest_release_tag(gh: object, repo_name: str) -> str | None:
+        if repo_name == "zenml-io/zenml-cloud-ui":
+            return ui_current_tag
+        raise AssertionError(f"Unexpected latest-release lookup for {repo_name}")
+
+    def fake_find_previous_tag(gh: object, repo_name: str, current_tag: str) -> str | None:
+        if repo_name == "zenml-io/zenml-cloud-api":
+            assert current_tag == "0.13.16"
+            return "0.13.15"
+        if repo_name == "zenml-io/zenml-cloud-ui":
+            assert current_tag == ui_current_tag
+            return ui_previous_tag
+        raise AssertionError(f"Unexpected previous-tag lookup for {repo_name}")
+
+    def fake_get_release_window(
+        gh: object,
+        repo_name: str,
+        since_tag: str | None,
+        until_tag: str,
+    ) -> tuple[datetime, datetime]:
+        return (
+            datetime(2026, 5, 1, tzinfo=timezone.utc),
+            datetime(2026, 6, 1, tzinfo=timezone.utc),
+        )
+
+    def fake_search_merged_prs(
+        gh: object,
+        repo_name: str,
+        base_branch: str,
+        since_date: datetime,
+        until_date: datetime,
+        label: str | None = None,
+    ) -> list[dict[str, Any]]:
+        searches.append((repo_name, label))
+        if repo_name == "zenml-io/zenml-cloud-api":
+            return []
+        if repo_name == "zenml-io/zenml-cloud-ui" and label == "release-notes":
+            return [
+                make_pr(1317, "zenml-io/zenml-cloud-ui", ["release-notes"]),
+                make_pr(1318, "zenml-io/zenml-cloud-ui", ["release-notes"]),
+            ]
+        if repo_name == "zenml-io/zenml-cloud-ui" and label == "breaking-change":
+            return [make_pr(1319, "zenml-io/zenml-cloud-ui", ["breaking-change"])]
+        return []
+
+    monkeypatch.setattr(uc, "find_latest_release_tag", fake_find_latest_release_tag)
+    monkeypatch.setattr(uc, "find_previous_tag", fake_find_previous_tag)
+    monkeypatch.setattr(uc, "get_release_window", fake_get_release_window)
+    monkeypatch.setattr(uc, "search_merged_prs", fake_search_merged_prs)
+    return searches
+
+
+def test_missing_consumed_state_file_returns_empty_state(tmp_path: Path) -> None:
+    state = uc.read_consumed_source_state(tmp_path / "missing-state")
+
+    assert state.version == 1
+    assert state.targets == {}
+
+
+def test_empty_consumed_state_file_returns_empty_state(tmp_path: Path) -> None:
+    path = tmp_path / "empty-state"
+    path.write_text("")
+
+    state = uc.read_consumed_source_state(path)
+
+    assert state.version == 1
+    assert state.targets == {}
+
+
+def test_consumed_state_round_trip(tmp_path: Path) -> None:
+    path = tmp_path / "state.json"
+    state = consumed_ui_01314_to_01315_state()
+
+    uc.write_consumed_source_state(state, path)
+    loaded = uc.read_consumed_source_state(path)
+
+    target = loaded.targets[
+        "zenml-io/zenml-cloud-api::gitbook-release-notes/pro-control-plane.md"
+    ]
+    assert target.consumed_windows[0].source_repo == "zenml-io/zenml-cloud-ui"
+    assert target.consumed_windows[0].previous_tag == "0.13.14"
+    assert target.consumed_windows[0].current_tag == "0.13.15"
+    assert "zenml-io/zenml-cloud-ui#1317" in target.consumed_prs
+
+
+def test_committed_seed_is_narrow_and_structured() -> None:
+    state = uc.read_consumed_source_state(REPO_ROOT / ".consumed_sources_state")
+    target = state.targets[
+        "zenml-io/zenml-cloud-api::gitbook-release-notes/pro-control-plane.md"
+    ]
+    seeded_pr = target.consumed_prs["zenml-io/zenml-cloud-ui#1317"]
+
+    assert state.bootstrap_note
+    assert "not a complete historical bootstrap" in state.bootstrap_note
+    assert seeded_pr.previous_tag == "0.13.14"
+    assert seeded_pr.current_tag == "0.13.15"
+    assert seeded_pr.source_window is None
+
+
+def test_invalid_consumed_state_file_fails_closed(tmp_path: Path) -> None:
+    path = tmp_path / "invalid-state"
+    path.write_text("[not-an-object]")
+
+    with pytest.raises(RuntimeError, match="Invalid JSON"):
+        uc.read_consumed_source_state(path)
+
+
+def test_window_pr_keys_are_reconciled_into_consumed_prs(tmp_path: Path) -> None:
+    path = tmp_path / "state.json"
+    path.write_text(
+        """
+        {
+          "version": 1,
+          "targets": {
+            "zenml-io/zenml-cloud-api::gitbook-release-notes/pro-control-plane.md": {
+              "trigger_repo": "zenml-io/zenml-cloud-api",
+              "markdown_file": "gitbook-release-notes/pro-control-plane.md",
+              "consumed_prs": {},
+              "consumed_windows": [
+                {
+                  "source_repo": "zenml-io/zenml-cloud-ui",
+                  "previous_tag": "0.13.14",
+                  "current_tag": "0.13.15",
+                  "consumed_by_release_tag": "0.13.15",
+                  "consumed_at": "2026-06-01T09:44:51.704139+00:00",
+                  "origin": "manual-test",
+                  "pr_keys": [
+                    "zenml-io/zenml-cloud-ui#1318",
+                    "zenml-io/zenml-cloud-ui#1317",
+                    "zenml-io/zenml-cloud-ui#1317"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+        """
+    )
+
+    state = uc.read_consumed_source_state(path)
+    target = state.targets[
+        "zenml-io/zenml-cloud-api::gitbook-release-notes/pro-control-plane.md"
+    ]
+
+    assert target.consumed_windows[0].pr_keys == [
+        "zenml-io/zenml-cloud-ui#1317",
+        "zenml-io/zenml-cloud-ui#1318",
+    ]
+    assert target.consumed_prs["zenml-io/zenml-cloud-ui#1317"].previous_tag == "0.13.14"
+    assert target.consumed_prs["zenml-io/zenml-cloud-ui#1317"].current_tag == "0.13.15"
+    assert target.consumed_prs["zenml-io/zenml-cloud-ui#1317"].source_window is None
+    assert target.consumed_prs["zenml-io/zenml-cloud-ui#1317"].origin == "manual-test"
+
+
+def test_conflicting_window_and_pr_facts_fail_closed(tmp_path: Path) -> None:
+    path = tmp_path / "state.json"
+    path.write_text(
+        """
+        {
+          "version": 1,
+          "targets": {
+            "zenml-io/zenml-cloud-api::gitbook-release-notes/pro-control-plane.md": {
+              "trigger_repo": "zenml-io/zenml-cloud-api",
+              "markdown_file": "gitbook-release-notes/pro-control-plane.md",
+              "consumed_prs": {
+                "zenml-io/zenml-cloud-ui#1317": {
+                  "source_repo": "zenml-io/zenml-cloud-ui",
+                  "number": 1317,
+                  "first_consumed_by_release_tag": "0.13.15",
+                  "first_consumed_at": "2026-06-01T09:44:51.704139+00:00",
+                  "previous_tag": "0.13.13",
+                  "current_tag": "0.13.14"
+                }
+              },
+              "consumed_windows": [
+                {
+                  "source_repo": "zenml-io/zenml-cloud-ui",
+                  "previous_tag": "0.13.14",
+                  "current_tag": "0.13.15",
+                  "consumed_by_release_tag": "0.13.15",
+                  "consumed_at": "2026-06-01T09:44:51.704139+00:00",
+                  "pr_keys": ["zenml-io/zenml-cloud-ui#1317"]
+                }
+              ]
+            }
+          }
+        }
+        """
+    )
+
+    with pytest.raises(RuntimeError, match="window tags conflict"):
+        uc.read_consumed_source_state(path)
+
+
+def test_stale_bundled_ui_window_is_skipped_for_release_notes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    searches = patch_release_window_resolution(monkeypatch)
+
+    collection = uc.collect_multi_source_prs(
+        gh=object(),
+        trigger_repo="zenml-io/zenml-cloud-api",
+        trigger_release_tag="0.13.16",
+        consumed_state=consumed_ui_01314_to_01315_state(),
+    )
+
+    assert collection.release_notes_prs == []
+    assert all(pr["repo"] != "zenml-io/zenml-cloud-ui" for pr in collection.release_notes_prs)
+    assert ("zenml-io/zenml-cloud-ui", "release-notes") not in searches
+    assert collection.skipped_windows[0].source_repo == "zenml-io/zenml-cloud-ui"
+    assert collection.skipped_windows[0].reason == uc.SKIP_REASON_ALREADY_CONSUMED_WINDOW
+    assert collection.skipped_windows[0].consumed_by_release_tag == "0.13.15"
+
+
+def test_stale_bundled_ui_window_is_skipped_for_breaking_prs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    searches = patch_release_window_resolution(monkeypatch)
+
+    collection = uc.collect_multi_source_prs(
+        gh=object(),
+        trigger_repo="zenml-io/zenml-cloud-api",
+        trigger_release_tag="0.13.16",
+        consumed_state=consumed_ui_01314_to_01315_state(),
+    )
+
+    assert collection.breaking_prs == []
+    assert ("zenml-io/zenml-cloud-ui", "breaking-change") not in searches
+    assert any(
+        skipped.reason == uc.SKIP_REASON_ALREADY_CONSUMED_WINDOW
+        for skipped in collection.skipped_windows
+    )
+
+
+def test_consumed_pr_key_is_filtered_even_when_window_is_new(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    patch_release_window_resolution(
+        monkeypatch,
+        ui_current_tag="0.13.16",
+        ui_previous_tag="0.13.15",
+    )
+    state = pro_target_state(
+        consumed_prs={
+            "zenml-io/zenml-cloud-ui#1317": uc.ConsumedPR(
+                source_repo="zenml-io/zenml-cloud-ui",
+                number=1317,
+                first_consumed_by_release_tag="0.13.15",
+                first_consumed_at="2026-06-01T09:44:51.704139+00:00",
+                previous_tag="0.13.14",
+                current_tag="0.13.15",
+            )
+        }
+    )
+
+    collection = uc.collect_multi_source_prs(
+        gh=object(),
+        trigger_repo="zenml-io/zenml-cloud-api",
+        trigger_release_tag="0.13.16",
+        consumed_state=state,
+    )
+
+    assert [pr["number"] for pr in collection.release_notes_prs] == [1318]
+    ui_collection = [
+        included
+        for included in collection.included_windows
+        if included.window.source_repo == "zenml-io/zenml-cloud-ui"
+    ][0]
+    assert ui_collection.filtered_pr_keys == ["zenml-io/zenml-cloud-ui#1317"]
+
+
+def test_source_window_report_exposes_included_and_skipped_windows(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    patch_release_window_resolution(monkeypatch)
+
+    collection = uc.collect_multi_source_prs(
+        gh=object(),
+        trigger_repo="zenml-io/zenml-cloud-api",
+        trigger_release_tag="0.13.16",
+        consumed_state=consumed_ui_01314_to_01315_state(),
+    )
+
+    report = uc.format_source_window_report(collection)
+
+    assert report.startswith(f"{uc.SOURCE_WINDOWS_START_MARKER}\n")
+    assert "included zenml-io/zenml-cloud-api 0.13.15 -> 0.13.16" in report
+    assert "skipped zenml-io/zenml-cloud-ui 0.13.14 -> 0.13.15" in report
+    assert "reason=already_consumed_window" in report
+    assert report.endswith(f"\n{uc.SOURCE_WINDOWS_END_MARKER}")
+
+def test_image_state_remains_separate_from_consumed_source_state(tmp_path: Path) -> None:
+    image_state_path = tmp_path / ".image_state"
+    uc.write_image_state(
+        uc.ImageState(
+            last_image_number=12,
+            last_release_tag="0.13.15",
+            last_markdown_file="gitbook-release-notes/pro-control-plane.md",
+            updated_at="2026-06-01T09:44:51.704139+00:00",
+        ),
+        image_state_path,
+    )
+
+    loaded = uc.read_image_state(image_state_path)
+    payload = uc._model_dump(loaded)
+
+    assert uc.IMAGE_STATE_FILE.name == ".image_state"
+    assert uc.CONSUMED_SOURCE_STATE_FILE.name == ".consumed_sources_state"
+    assert set(payload) == {
+        "last_image_number",
+        "last_release_tag",
+        "last_markdown_file",
+        "updated_at",
+    }


### PR DESCRIPTION
## Summary

This fixes the duplicate release-note issue found in PR #75 by preventing already-consumed bundled source windows from being selected again.

Concrete bug:
- `zenml-cloud-api@0.13.16` correctly used the API window `0.13.15 → 0.13.16`.
- The bundled `zenml-cloud-ui` source independently resolved to its latest release, still `0.13.15`.
- That re-selected the already-used UI window `0.13.14 → 0.13.15`, causing duplicate Pro release notes.

## What changed

- Added `.consumed_sources_state`, a dedicated ledger for finalized source windows / consumed PRs.
- Added deterministic replay prevention before LLM summarization.
- Split the new logic into:
  - `scripts/consumed_sources.py`
  - `scripts/source_windows.py`
- Kept widget and release-notes PRs separate because different teams review them.
- Put `.consumed_sources_state` in the release-notes PR with the markdown it protects.
- Added source-window metadata to generated PR bodies.
- Added fail-closed workflow handling if source-window markers are missing.
- Added regression coverage for the stale bundled UI window scenario.
- Updated README/CLAUDE docs for the new state file and policy.

## Tests

- `uv run --with pytest --with requests --with PyGithub --with anthropic --with jsonschema --with pydantic --with python-slugify --with tenacity pytest tests/test_update_changelog_grouped_retry.py tests/test_consumed_source_windows.py`
  - `20 passed`
- `uv run --with pytest --with requests --with PyGithub --with anthropic --with jsonschema --with pydantic --with python-slugify --with tenacity pytest`
  - `20 passed`
- Workflow YAML + module import smoke test passed.
- Direct script-dir import smoke test passed.

## Related

- PR #75 had duplicated Pro release-note content from `0.13.15`.
- I also pushed a cleanup commit to PR #75's branch to remove the duplicated `0.13.16` section.
