### PR TITLE
Harden GitHub release note sync tests

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,0 +1,25 @@
+name: Pytest
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  pytest:
+    name: Run pytest
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v7
+
+      - name: Run pytest
+        run: uv run scripts/run_pytest.py

--- a/.github/workflows/sync-zenml-release-notes.yml
+++ b/.github/workflows/sync-zenml-release-notes.yml
@@ -15,62 +15,31 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'core-squad') }}
     steps:
+      - name: Checkout repository at merge commit
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.merge_commit_sha }}
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v7
+
       - name: Parse sync meta from PR body
         id: meta
         env:
           PR_BODY: ${{ github.event.pull_request.body }}
         run: |
           set -euo pipefail
+          uv run scripts/sync_zenml_github_release_notes.py parse-sync-meta
 
-          # PR body is free-form; we rely on a delimited HTML comment block for machine parsing.
-          body_file="$(mktemp)"
-          printf "%s" "${PR_BODY:-}" | tr -d '\r' > "$body_file"
-
-          meta_block="$(sed -n '/ZENML_CHANGELOG_SYNC_META/,/END_ZENML_CHANGELOG_SYNC_META/p' "$body_file" || true)"
-          if [ -z "$meta_block" ]; then
-            echo "ERROR: ZENML_CHANGELOG_SYNC_META block not found in PR body." >&2
-            exit 1
-          fi
-
-          source_repo="$(printf "%s\n" "$meta_block" | grep -E '^source_repo=' | head -n 1 | sed -E 's/^source_repo=//')"
-          release_tag="$(printf "%s\n" "$meta_block" | grep -E '^release_tag=' | head -n 1 | sed -E 's/^release_tag=//')"
-          markdown_file="$(printf "%s\n" "$meta_block" | grep -E '^markdown_file=' | head -n 1 | sed -E 's/^markdown_file=//')"
-
-          if [ -z "$source_repo" ] || [ -z "$release_tag" ] || [ -z "$markdown_file" ]; then
-            echo "ERROR: Missing required meta keys. Parsed values:" >&2
-            echo "source_repo=$source_repo" >&2
-            echo "release_tag=$release_tag" >&2
-            echo "markdown_file=$markdown_file" >&2
-            exit 1
-          fi
-
-          echo "source_repo=$source_repo" >> "$GITHUB_OUTPUT"
-          echo "release_tag=$release_tag" >> "$GITHUB_OUTPUT"
-          echo "markdown_file=$markdown_file" >> "$GITHUB_OUTPUT"
-
-      - name: Check whether this PR should sync OSS release notes
-        id: gate
+      - name: Report skipped non-OSS release notes sync
+        if: ${{ steps.meta.outputs.should_sync != 'true' }}
+        env:
+          SOURCE_REPO: ${{ steps.meta.outputs.source_repo }}
         run: |
-          set -euo pipefail
-          if [ "${{ steps.meta.outputs.source_repo }}" != "zenml-io/zenml" ]; then
-            echo "should_sync=false" >> "$GITHUB_OUTPUT"
-            echo "Skipping: source_repo is '${{ steps.meta.outputs.source_repo }}' (only sync zenml-io/zenml)." >&2
-            exit 0
-          fi
-          echo "should_sync=true" >> "$GITHUB_OUTPUT"
-
-      - name: Checkout repository at merge commit
-        if: ${{ steps.gate.outputs.should_sync == 'true' }}
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.merge_commit_sha }}
-
-      - name: Set up uv
-        if: ${{ steps.gate.outputs.should_sync == 'true' }}
-        uses: astral-sh/setup-uv@v7
+          echo "Skipping: source_repo is '${SOURCE_REPO}' (only sync zenml-io/zenml)."
 
       - name: Sync release notes to zenml-io/zenml GitHub Release
-        if: ${{ steps.gate.outputs.should_sync == 'true' }}
+        if: ${{ steps.meta.outputs.should_sync == 'true' }}
         env:
           ZENML_RELEASE_SYNC_TOKEN: ${{ secrets.ZENML_RELEASE_SYNC_TOKEN }}
           RELEASE_TAG: ${{ steps.meta.outputs.release_tag }}

--- a/README.md
+++ b/README.md
@@ -91,6 +91,17 @@ Generated PR bodies include a `Source windows` block. Reviewers should check whi
 - From a source repo, send a `repository_dispatch` with `event_type: release-published` and payload fields: `repo`, `repo_name`, `release_tag`, `release_name`, `release_url`, `release_body`, `published_at`, `is_prerelease`.
 - In this repo, you can also re-run the `Process release` workflow from the Actions tab on a past dispatch if needed.
 - Validate locally (optional) by running a JSON Schema check of `changelog.json` against `changelog_schema/announcement-schema.json`.
+- Run the local pytest suite with the same dependency set used by CI:
+
+```bash
+uv run scripts/run_pytest.py
+```
+
+## OSS GitHub Release Sync Contract
+
+Release-notes PR bodies include a hidden `ZENML_CHANGELOG_SYNC_META` block. After a release-notes PR is merged, `.github/workflows/sync-zenml-release-notes.yml` parses that block with `scripts/sync_zenml_github_release_notes.py parse-sync-meta`.
+
+The GitHub Release sync only proceeds when the parsed `source_repo` is `zenml-io/zenml`. The actual OSS sync step is currently pinned to `gitbook-release-notes/server-sdk.md`; the parsed `markdown_file` is required and must match that pinned path, but it is not used as a dynamic sync input yet.
 
 ## Uploading Feature Images
 

--- a/scripts/run_pytest.py
+++ b/scripts/run_pytest.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     # Keep this list broad enough for import-time dependencies of tested scripts,
+#     # especially scripts/update_changelog.py.
+#     "pytest",
+#     "requests",
+#     "PyGithub",
+#     "anthropic",
+#     "jsonschema",
+#     "pydantic",
+#     "python-slugify",
+#     "tenacity",
+# ]
+# ///
+from __future__ import annotations
+
+import subprocess
+import sys
+from collections.abc import Sequence
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = list(sys.argv[1:] if argv is None else argv)
+    if not args:
+        args = ["-q"]
+    return subprocess.call([sys.executable, "-m", "pytest", *args])
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/sync_zenml_github_release_notes.py
+++ b/scripts/sync_zenml_github_release_notes.py
@@ -9,12 +9,29 @@ from __future__ import annotations
 
 import os
 import re
+import sys
+from collections.abc import Sequence
+from dataclasses import dataclass, fields
 from pathlib import Path
-from typing import Any, Dict, Optional
+from typing import Any
 
 import requests
 
 GITHUB_API_BASE_URL = "https://api.github.com"
+START_SYNC_META_SENTINEL = "ZENML_CHANGELOG_SYNC_META"
+END_SYNC_META_SENTINEL = "END_ZENML_CHANGELOG_SYNC_META"
+OSS_SYNC_SOURCE_REPO = "zenml-io/zenml"
+OSS_SYNC_MARKDOWN_FILE = "gitbook-release-notes/server-sdk.md"
+
+
+@dataclass(frozen=True)
+class SyncMetadata:
+    source_repo: str
+    release_tag: str
+    markdown_file: str
+
+
+REQUIRED_SYNC_META_KEYS = tuple(field.name for field in fields(SyncMetadata))
 
 
 def _require_env(name: str) -> str:
@@ -22,6 +39,108 @@ def _require_env(name: str) -> str:
     if value is None or not value.strip():
         raise RuntimeError(f"Missing required environment variable: {name}")
     return value.strip()
+
+
+def _normalized_pr_body_lines(pr_body: str) -> list[str]:
+    return pr_body.replace("\r\n", "\n").replace("\r", "\n").split("\n")
+
+
+def parse_sync_metadata_from_pr_body(pr_body: str) -> SyncMetadata:
+    """Parse hidden release-note sync metadata from a merged PR body.
+
+    The producer wraps the metadata in an HTML comment, but the authoritative
+    boundaries are the exact sentinel lines. This deliberately fails closed on
+    broken required metadata so the workflow does not sync the wrong release.
+    """
+    blocks: list[list[str]] = []
+    current_block: list[str] | None = None
+
+    for line_number, raw_line in enumerate(_normalized_pr_body_lines(pr_body), start=1):
+        stripped = raw_line.strip()
+        if stripped == START_SYNC_META_SENTINEL:
+            if current_block is not None:
+                raise RuntimeError(
+                    "Found a nested ZENML_CHANGELOG_SYNC_META start sentinel "
+                    f"before the previous block ended at line {line_number}."
+                )
+            current_block = []
+            continue
+
+        if stripped == END_SYNC_META_SENTINEL:
+            if current_block is None:
+                raise RuntimeError(
+                    "Found END_ZENML_CHANGELOG_SYNC_META without a matching start sentinel."
+                )
+            blocks.append(current_block)
+            current_block = None
+            continue
+
+        if current_block is not None:
+            current_block.append(raw_line)
+
+    if current_block is not None:
+        raise RuntimeError("ZENML_CHANGELOG_SYNC_META block is missing its end sentinel.")
+
+    if not blocks:
+        raise RuntimeError("ZENML_CHANGELOG_SYNC_META block not found in PR body.")
+
+    if len(blocks) > 1:
+        raise RuntimeError("Expected exactly one ZENML_CHANGELOG_SYNC_META block, found multiple.")
+
+    values: dict[str, str] = {}
+    required_keys = set(REQUIRED_SYNC_META_KEYS)
+    for raw_line in blocks[0]:
+        stripped = raw_line.strip()
+        if not stripped:
+            continue
+        if "=" not in stripped:
+            raise RuntimeError(f"Malformed sync metadata line without '=': {stripped!r}")
+
+        key, value = (part.strip() for part in stripped.split("=", 1))
+        if key not in required_keys:
+            continue
+        if key in values:
+            raise RuntimeError(f"Duplicate sync metadata key: {key}")
+        if not value:
+            raise RuntimeError(f"Sync metadata key '{key}' must not be empty.")
+        values[key] = value
+
+    missing_keys = [key for key in REQUIRED_SYNC_META_KEYS if key not in values]
+    if missing_keys:
+        raise RuntimeError(
+            "Missing required sync metadata key(s): " + ", ".join(missing_keys)
+        )
+
+    metadata = SyncMetadata(**values)
+    if (
+        metadata.source_repo == OSS_SYNC_SOURCE_REPO
+        and metadata.markdown_file != OSS_SYNC_MARKDOWN_FILE
+    ):
+        raise RuntimeError(
+            "Refusing OSS sync: parsed markdown_file is "
+            f"'{metadata.markdown_file}', but OSS sync is pinned to "
+            f"'{OSS_SYNC_MARKDOWN_FILE}'."
+        )
+    return metadata
+
+
+def should_sync_oss_release_notes(metadata: SyncMetadata) -> bool:
+    return metadata.source_repo == OSS_SYNC_SOURCE_REPO
+
+
+def write_sync_metadata_github_outputs(pr_body: str, output_path: Path) -> None:
+    metadata = parse_sync_metadata_from_pr_body(pr_body)
+    should_sync = "true" if should_sync_oss_release_notes(metadata) else "false"
+    with output_path.open("a", encoding="utf-8") as output_file:
+        for key in REQUIRED_SYNC_META_KEYS:
+            output_file.write(f"{key}={getattr(metadata, key)}\n")
+        output_file.write(f"should_sync={should_sync}\n")
+
+
+def run_parse_sync_metadata_mode() -> None:
+    pr_body = os.environ.get("PR_BODY", "")
+    github_output = _require_env("GITHUB_OUTPUT")
+    write_sync_metadata_github_outputs(pr_body=pr_body, output_path=Path(github_output))
 
 
 def extract_release_section_from_server_sdk(markdown_text: str, release_tag: str) -> str:
@@ -58,10 +177,11 @@ def extract_release_section_from_server_sdk(markdown_text: str, release_tag: str
 
     content_start = heading_line_end + 1
 
-    next_heading_match = re.search(r"^##\s+", markdown_text[content_start:], flags=re.MULTILINE)
+    section_tail = markdown_text[content_start:]
+    next_heading_match = re.search(r"^##\s+", section_tail, flags=re.MULTILINE)
     next_heading_index = content_start + next_heading_match.start() if next_heading_match else None
 
-    separator_match = re.search(r"^\*\*\*\s*$", markdown_text[content_start:], flags=re.MULTILINE)
+    separator_match = re.search(r"^\*\*\*\s*$", section_tail, flags=re.MULTILINE)
     separator_index = content_start + separator_match.start() if separator_match else None
 
     candidates = [idx for idx in [next_heading_index, separator_index] if idx is not None]
@@ -104,7 +224,7 @@ def extract_release_section_from_server_sdk(markdown_text: str, release_tag: str
     return section.strip()
 
 
-def _github_headers(token: str) -> Dict[str, str]:
+def _github_headers(token: str) -> dict[str, str]:
     return {
         "Authorization": f"Bearer {token}",
         "Accept": "application/vnd.github+json",
@@ -113,7 +233,7 @@ def _github_headers(token: str) -> Dict[str, str]:
     }
 
 
-def fetch_release_by_tag(token: str, repo: str, tag: str) -> Dict[str, Any]:
+def fetch_release_by_tag(token: str, repo: str, tag: str) -> dict[str, Any]:
     url = f"{GITHUB_API_BASE_URL}/repos/{repo}/releases/tags/{tag}"
     resp = requests.get(url, headers=_github_headers(token), timeout=30)
     if resp.status_code == 404:
@@ -176,16 +296,14 @@ def main() -> None:
     token = _require_env("ZENML_RELEASE_SYNC_TOKEN")
     release_tag = _require_env("RELEASE_TAG")
 
-    target_repo = os.environ.get("TARGET_REPO", "zenml-io/zenml").strip() or "zenml-io/zenml"
-    markdown_file = os.environ.get(
-        "MARKDOWN_FILE", "gitbook-release-notes/server-sdk.md"
-    ).strip() or "gitbook-release-notes/server-sdk.md"
+    target_repo = os.environ.get("TARGET_REPO", OSS_SYNC_SOURCE_REPO).strip() or OSS_SYNC_SOURCE_REPO
+    markdown_file = os.environ.get("MARKDOWN_FILE", OSS_SYNC_MARKDOWN_FILE).strip() or OSS_SYNC_MARKDOWN_FILE
 
     md_path = Path(markdown_file)
-    if not md_path.exists():
-        raise RuntimeError(f"Markdown file not found: {markdown_file}")
-
-    markdown_text = md_path.read_text(encoding="utf-8")
+    try:
+        markdown_text = md_path.read_text(encoding="utf-8")
+    except FileNotFoundError as exc:
+        raise RuntimeError(f"Markdown file not found: {markdown_file}") from exc
     extracted = extract_release_section_from_server_sdk(markdown_text, release_tag)
     if not extracted.strip():
         raise RuntimeError(
@@ -210,5 +328,20 @@ def main() -> None:
     print(f"Synced GitBook release notes to GitHub Release: {target_repo}@{release_tag}")
 
 
+def cli(argv: Sequence[str] | None = None) -> None:
+    args = list(sys.argv[1:] if argv is None else argv)
+    if not args:
+        main()
+        return
+
+    if args == ["parse-sync-meta"]:
+        run_parse_sync_metadata_mode()
+        return
+
+    raise SystemExit(
+        "Usage: sync_zenml_github_release_notes.py [parse-sync-meta]"
+    )
+
+
 if __name__ == "__main__":
-    main()
+    cli()

--- a/tests/test_sync_zenml_github_release_notes.py
+++ b/tests/test_sync_zenml_github_release_notes.py
@@ -1,0 +1,343 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from scripts import sync_zenml_github_release_notes as sync
+from scripts import update_changelog as uc
+
+
+def valid_sync_meta_body(
+    source_repo: str = "zenml-io/zenml",
+    release_tag: str = "0.85.0",
+    markdown_file: str = "gitbook-release-notes/server-sdk.md",
+    extra_lines: str = "",
+) -> str:
+    extra = f"{extra_lines}\n" if extra_lines else ""
+    return f"""<!--
+{sync.START_SYNC_META_SENTINEL}
+source_repo={source_repo}
+release_tag={release_tag}
+markdown_file={markdown_file}
+{extra}{sync.END_SYNC_META_SENTINEL}
+-->
+
+Automated release notes update.
+"""
+
+
+def test_extract_release_section_matches_update_changelog_header_and_footer() -> None:
+    header = uc.render_release_header(
+        release_tag="0.85.0",
+        published_at="2026-06-02T10:11:12Z",
+        image_number=7,
+        source_repo="zenml-io/zenml",
+    )
+    footer = uc.render_release_footer(
+        source_repo="zenml-io/zenml",
+        release_url="https://github.com/zenml-io/zenml/releases/tag/0.85.0",
+    )
+    markdown = (
+        "# Server SDK\n\n"
+        f"{header}"
+        "<!-- generated bookkeeping comment -->\n"
+        "### Highlights\n\n"
+        "ZenML now keeps release notes safer.\n\n"
+        "#### Details\n\n"
+        "Nested headings remain part of the release.\n\n"
+        f"{footer}\n\n"
+        "## 0.84.0 (2026-05-01)\n\nOlder content.\n"
+    )
+
+    extracted = sync.extract_release_section_from_server_sdk(markdown, "0.85.0")
+
+    assert "### Highlights" in extracted
+    assert "#### Details" in extracted
+    assert "ZenML now keeps release notes safer." in extracted
+    assert "Nested headings remain part of the release." in extracted
+    assert "See what's new and improved" not in extracted
+    assert "<img" not in extracted
+    assert "<!--" not in extracted
+    assert "View full release on GitHub" not in extracted
+    assert "***" not in extracted
+    assert "Older content" not in extracted
+
+
+def test_extract_release_section_stops_at_separator() -> None:
+    markdown = """## 1.2.3 (2026-06-02)
+
+Release body.
+
+***
+
+This is after the separator.
+"""
+
+    extracted = sync.extract_release_section_from_server_sdk(markdown, "1.2.3")
+
+    assert extracted == "Release body."
+
+
+def test_extract_release_section_stops_at_next_release_heading_not_subheadings() -> None:
+    markdown = """## 1.2.3 (2026-06-02)
+
+### Kept subsection
+
+Keep this subsection.
+
+#### Also kept
+
+Keep this deeper subsection.
+
+## 1.2.2 (2026-05-01)
+
+Do not include older release.
+"""
+
+    extracted = sync.extract_release_section_from_server_sdk(markdown, "1.2.3")
+
+    assert "### Kept subsection" in extracted
+    assert "#### Also kept" in extracted
+    assert "Do not include older release" not in extracted
+
+
+def test_extract_release_section_missing_heading_fails_clearly() -> None:
+    with pytest.raises(RuntimeError, match="Release heading not found"):
+        sync.extract_release_section_from_server_sdk("## 1.2.2 (2026-05-01)\n", "1.2.3")
+
+
+def test_extract_release_section_empty_tag_fails_clearly() -> None:
+    with pytest.raises(ValueError, match="release_tag must be a non-empty string"):
+        sync.extract_release_section_from_server_sdk("## 1.2.3 (2026-06-02)\n", "  ")
+
+
+def test_upsert_inserts_managed_block_before_whats_changed() -> None:
+    updated = sync.upsert_prepended_block(
+        existing_body="Intro text.\n\n## What's Changed\n\n* Existing release item\n",
+        new_block="GitBook release notes.",
+        tag="1.2.3",
+    )
+
+    assert updated.index("GitBook release notes.") < updated.index("## What's Changed")
+    assert updated.startswith("Intro text.")
+    assert updated.endswith("* Existing release item\n")
+
+
+def test_upsert_prepends_when_whats_changed_is_absent() -> None:
+    updated = sync.upsert_prepended_block(
+        existing_body="Existing release body.",
+        new_block="GitBook release notes.",
+        tag="1.2.3",
+    )
+
+    assert updated.startswith("<!-- ZENML_GITBOOK_RELEASE_NOTES_START tag=1.2.3 -->")
+    assert "GitBook release notes.\n<!-- ZENML_GITBOOK_RELEASE_NOTES_END tag=1.2.3 -->\n\nExisting release body." in updated
+
+
+def test_upsert_replaces_same_tag_managed_block() -> None:
+    existing = """<!-- ZENML_GITBOOK_RELEASE_NOTES_START tag=1.2.3 -->
+Old managed notes.
+<!-- ZENML_GITBOOK_RELEASE_NOTES_END tag=1.2.3 -->
+
+## What's Changed
+
+* Existing release item
+"""
+
+    updated = sync.upsert_prepended_block(
+        existing_body=existing,
+        new_block="New managed notes.",
+        tag="1.2.3",
+    )
+
+    assert "New managed notes." in updated
+    assert "Old managed notes." not in updated
+    assert updated.count("ZENML_GITBOOK_RELEASE_NOTES_START tag=1.2.3") == 1
+
+
+def test_upsert_preserves_other_tag_managed_blocks() -> None:
+    other_tag_block = """<!-- ZENML_GITBOOK_RELEASE_NOTES_START tag=1.2.2 -->
+Older managed notes.
+<!-- ZENML_GITBOOK_RELEASE_NOTES_END tag=1.2.2 -->"""
+    existing = f"{other_tag_block}\n\n## What's Changed\n\n* Existing release item\n"
+
+    updated = sync.upsert_prepended_block(
+        existing_body=existing,
+        new_block="New managed notes.",
+        tag="1.2.3",
+    )
+
+    assert "Older managed notes." in updated
+    assert "New managed notes." in updated
+    assert updated.count("ZENML_GITBOOK_RELEASE_NOTES_START tag=") == 2
+
+
+def test_upsert_is_idempotent_for_same_block_and_tag() -> None:
+    once = sync.upsert_prepended_block(
+        existing_body="## What's Changed\n\n* Existing release item\n",
+        new_block="Managed notes.",
+        tag="1.2.3",
+    )
+    twice = sync.upsert_prepended_block(
+        existing_body=once,
+        new_block="Managed notes.",
+        tag="1.2.3",
+    )
+
+    assert once == twice
+
+
+def test_parse_sync_metadata_happy_path_with_unknown_extra_key() -> None:
+    metadata = sync.parse_sync_metadata_from_pr_body(
+        valid_sync_meta_body(extra_lines="future_key=future value")
+    )
+
+    assert metadata == sync.SyncMetadata(
+        source_repo="zenml-io/zenml",
+        release_tag="0.85.0",
+        markdown_file="gitbook-release-notes/server-sdk.md",
+    )
+
+
+def test_parse_sync_metadata_accepts_crlf_and_trims_values() -> None:
+    body = valid_sync_meta_body(
+        source_repo=" zenml-io/zenml ",
+        release_tag=" 0.85.0 ",
+        markdown_file=" gitbook-release-notes/server-sdk.md ",
+    ).replace("\n", "\r\n")
+
+    metadata = sync.parse_sync_metadata_from_pr_body(body)
+
+    assert metadata.source_repo == "zenml-io/zenml"
+    assert metadata.release_tag == "0.85.0"
+    assert metadata.markdown_file == "gitbook-release-notes/server-sdk.md"
+
+
+def test_parse_sync_metadata_does_not_count_end_sentinel_as_second_start() -> None:
+    metadata = sync.parse_sync_metadata_from_pr_body(valid_sync_meta_body())
+
+    assert metadata.release_tag == "0.85.0"
+
+
+@pytest.mark.parametrize(
+    ("body", "error_match"),
+    [
+        ("No metadata here.", "block not found"),
+        (
+            f"<!--\n{sync.START_SYNC_META_SENTINEL}\nsource_repo=zenml-io/zenml\n",
+            "missing its end sentinel",
+        ),
+        (
+            f"""<!--
+{sync.START_SYNC_META_SENTINEL}
+source_repo=zenml-io/zenml
+release_tag=0.85.0
+{sync.END_SYNC_META_SENTINEL}
+-->""",
+            "markdown_file",
+        ),
+        (
+            f"""<!--
+{sync.START_SYNC_META_SENTINEL}
+source_repo=zenml-io/zenml
+source_repo=zenml-io/zenml-cloud-api
+release_tag=0.85.0
+markdown_file=gitbook-release-notes/server-sdk.md
+{sync.END_SYNC_META_SENTINEL}
+-->""",
+            "Duplicate sync metadata key: source_repo",
+        ),
+        (
+            f"""<!--
+{sync.START_SYNC_META_SENTINEL}
+source_repo=zenml-io/zenml
+release_tag=
+markdown_file=gitbook-release-notes/server-sdk.md
+{sync.END_SYNC_META_SENTINEL}
+-->""",
+            "release_tag.*must not be empty",
+        ),
+        (
+            valid_sync_meta_body() + "\n" + valid_sync_meta_body(release_tag="0.85.1"),
+            "found multiple",
+        ),
+        (
+            valid_sync_meta_body(markdown_file="gitbook-release-notes/pro-control-plane.md"),
+            "Refusing OSS sync",
+        ),
+    ],
+)
+def test_parse_sync_metadata_fails_closed_on_broken_required_data(
+    body: str,
+    error_match: str,
+) -> None:
+    with pytest.raises(RuntimeError, match=error_match):
+        sync.parse_sync_metadata_from_pr_body(body)
+
+
+def test_should_sync_oss_release_notes_only_for_zenml_repo() -> None:
+    assert sync.should_sync_oss_release_notes(
+        sync.SyncMetadata(
+            source_repo="zenml-io/zenml",
+            release_tag="0.85.0",
+            markdown_file="gitbook-release-notes/server-sdk.md",
+        )
+    )
+    assert not sync.should_sync_oss_release_notes(
+        sync.SyncMetadata(
+            source_repo="zenml-io/zenml-cloud-api",
+            release_tag="0.13.15",
+            markdown_file="gitbook-release-notes/pro-control-plane.md",
+        )
+    )
+
+
+def test_parser_mode_writes_github_outputs(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    output_path = tmp_path / "github-output.txt"
+    monkeypatch.setenv("PR_BODY", valid_sync_meta_body())
+    monkeypatch.setenv("GITHUB_OUTPUT", str(output_path))
+
+    sync.run_parse_sync_metadata_mode()
+
+    assert output_path.read_text(encoding="utf-8") == (
+        "source_repo=zenml-io/zenml\n"
+        "release_tag=0.85.0\n"
+        "markdown_file=gitbook-release-notes/server-sdk.md\n"
+        "should_sync=true\n"
+    )
+
+
+def test_cli_dispatches_parse_sync_meta_mode(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    output_path = tmp_path / "github-output.txt"
+    monkeypatch.setenv("PR_BODY", valid_sync_meta_body())
+    monkeypatch.setenv("GITHUB_OUTPUT", str(output_path))
+
+    sync.cli(["parse-sync-meta"])
+
+    assert "should_sync=true\n" in output_path.read_text(encoding="utf-8")
+
+
+def test_parser_mode_writes_should_sync_false_for_non_oss_source(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    output_path = tmp_path / "github-output.txt"
+    monkeypatch.setenv(
+        "PR_BODY",
+        valid_sync_meta_body(
+            source_repo="zenml-io/zenml-cloud-api",
+            release_tag="0.13.15",
+            markdown_file="gitbook-release-notes/pro-control-plane.md",
+        ),
+    )
+    monkeypatch.setenv("GITHUB_OUTPUT", str(output_path))
+
+    sync.run_parse_sync_metadata_mode()
+
+    assert "should_sync=false\n" in output_path.read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary

This PR hardens the post-merge GitBook → GitHub Release sync path for OSS release notes.

The main change is moving the fragile PR-body metadata parsing out of workflow shell (`sed`/`grep`) and into tested Python, while keeping the existing `ZENML_CHANGELOG_SYNC_META` block format and keeping OSS sync pinned to `gitbook-release-notes/server-sdk.md`.

## What changed

- Added a centralized pytest runner: `uv run scripts/run_pytest.py`
- Added a new pytest CI workflow for PRs and pushes to `main`
- Added focused tests for `scripts/sync_zenml_github_release_notes.py`, covering:
  - GitBook release-section extraction
  - GitBook-only cleanup
  - managed GitHub Release block upsert/idempotency
  - PR-body sync metadata parsing
  - parser CLI dispatch used by the workflow
- Updated `.github/workflows/sync-zenml-release-notes.yml` to use the tested Python parser instead of shell parsing
- Kept the actual OSS sync file pinned to `gitbook-release-notes/server-sdk.md`
- Documented the local pytest command and OSS sync contract in the README

## Validation

- `uv run scripts/run_pytest.py` → `44 passed`
- `git diff --cached --check` passed before commit
- Simplify review run; findings fixed
- Thermonuclear code quality review run; findings fixed
- Final Oracle review found no actionable findings

## Notes for reviewers

The broader structured-metadata cleanup for `process-release.yml` is intentionally **not** part of this PR. This PR only hardens the consumer side of the existing release-notes sync metadata contract.
