### PR TITLE
Use structured changelog workflow outputs

### DIFF
--- a/.github/workflows/process-release.yml
+++ b/.github/workflows/process-release.yml
@@ -31,11 +31,11 @@ jobs:
   generate:
     runs-on: ubuntu-latest
     outputs:
-      has_changes: ${{ steps.check_changes.outputs.has_changes }}
-      markdown_file: ${{ steps.extract_md.outputs.markdown_file }}
-      breaking_changes: ${{ steps.extract_breaking.outputs.breaking_changes }}
-      needs_attention: ${{ steps.extract_attention.outputs.needs_attention }}
-      source_windows: ${{ steps.extract_source_windows.outputs.source_windows }}
+      has_changes: ${{ steps.workflow_outputs.outputs.has_changes }}
+      markdown_file: ${{ steps.workflow_outputs.outputs.markdown_file }}
+      breaking_changes: ${{ steps.workflow_outputs.outputs.breaking_changes }}
+      needs_attention: ${{ steps.workflow_outputs.outputs.needs_attention }}
+      source_windows: ${{ steps.workflow_outputs.outputs.source_windows }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -52,99 +52,42 @@ jobs:
           RELEASE_TAG: ${{ env.RELEASE_TAG }}
           RELEASE_URL: ${{ env.RELEASE_URL }}
           PUBLISHED_AT: ${{ env.PUBLISHED_AT }}
+          CHANGELOG_WORKFLOW_RESULT: changelog_workflow_result.json
         run: |
           set -euo pipefail
-          uv run scripts/update_changelog.py | tee changelog_output.txt
+          uv run scripts/update_changelog.py
 
-      - name: Check for changes
-        id: check_changes
+      - name: Publish changelog workflow outputs
+        id: workflow_outputs
+        env:
+          CHANGELOG_WORKFLOW_RESULT: changelog_workflow_result.json
         run: |
-          if grep -q '^NO_CHANGES_NEEDED$' changelog_output.txt; then
-            echo "No release-notes PRs found — skipping changelog generation."
-            echo "has_changes=false" >> "$GITHUB_OUTPUT"
-          else
-            echo "has_changes=true" >> "$GITHUB_OUTPUT"
-          fi
+          set -euo pipefail
+          uv run scripts/workflow_result.py write-github-outputs
 
       - name: Validate changelog.json
-        if: steps.check_changes.outputs.has_changes == 'true'
+        if: steps.workflow_outputs.outputs.has_changes == 'true'
         uses: cardinalby/schema-validator-action@v3
         with:
           file: ./changelog.json
           schema: ./changelog_schema/announcement-schema.json
 
-      - name: Extract updated markdown file
-        if: steps.check_changes.outputs.has_changes == 'true'
-        id: extract_md
-        run: |
-          set -euo pipefail
-          md=$(awk '/^UPDATED_MARKDOWN_FILE$/{flag=1;next}/^END_UPDATED_MARKDOWN_FILE$/{flag=0}flag{print; exit}' changelog_output.txt | tr -d '\r')
-          if [ -z "$md" ]; then
-            echo "ERROR: UPDATED_MARKDOWN_FILE marker not found in changelog_output.txt" >&2
-            exit 1
-          fi
-          echo "markdown_file=$md" >> "$GITHUB_OUTPUT"
-
-      - name: Extract breaking changes
-        if: steps.check_changes.outputs.has_changes == 'true'
-        id: extract_breaking
-        run: |
-          set -euo pipefail
-          breaking=$(awk '/^BREAKING_CHANGES$/{flag=1;next}/^END_BREAKING_CHANGES$/{flag=0}flag{print}' changelog_output.txt | tr -d '\r')
-          {
-            echo "breaking_changes<<EOF"
-            echo "${breaking}"
-            echo "EOF"
-          } >> "$GITHUB_OUTPUT"
-
-      - name: Extract attention items
-        if: steps.check_changes.outputs.has_changes == 'true'
-        id: extract_attention
-        run: |
-          set -euo pipefail
-          attention=$(awk '/^NEEDS_ATTENTION$/{flag=1;next}/^UPDATED_MARKDOWN_FILE$/{flag=0}flag{print}' changelog_output.txt | tr -d '\r')
-          {
-            echo "needs_attention<<EOF"
-            echo "${attention}"
-            echo "EOF"
-          } >> "$GITHUB_OUTPUT"
-
-      - name: Extract source windows
-        if: steps.check_changes.outputs.has_changes == 'true'
-        id: extract_source_windows
-        run: |
-          set -euo pipefail
-          if ! grep -q '^SOURCE_WINDOWS$' changelog_output.txt || ! grep -q '^END_SOURCE_WINDOWS$' changelog_output.txt; then
-            echo "ERROR: SOURCE_WINDOWS markers not found in changelog_output.txt" >&2
-            exit 1
-          fi
-          source_windows=$(awk '/^SOURCE_WINDOWS$/{flag=1;next}/^END_SOURCE_WINDOWS$/{flag=0}flag{print}' changelog_output.txt | tr -d '\r')
-          if [ -z "$source_windows" ]; then
-            echo "ERROR: SOURCE_WINDOWS block was empty" >&2
-            exit 1
-          fi
-          {
-            echo "source_windows<<EOF"
-            echo "${source_windows}"
-            echo "EOF"
-          } >> "$GITHUB_OUTPUT"
-
       - name: Create widget patch
-        if: steps.check_changes.outputs.has_changes == 'true'
+        if: steps.workflow_outputs.outputs.has_changes == 'true'
         run: |
           set -euo pipefail
           git diff --binary -- changelog.json .image_state > widget.patch
 
       - name: Create release notes patch
-        if: steps.check_changes.outputs.has_changes == 'true'
+        if: steps.workflow_outputs.outputs.has_changes == 'true'
         env:
-          MARKDOWN_FILE: ${{ steps.extract_md.outputs.markdown_file }}
+          MARKDOWN_FILE: ${{ steps.workflow_outputs.outputs.markdown_file }}
         run: |
           set -euo pipefail
           git diff --binary -- "$MARKDOWN_FILE" .consumed_sources_state > release-notes.patch
 
       - name: Upload widget patch artifact
-        if: steps.check_changes.outputs.has_changes == 'true'
+        if: steps.workflow_outputs.outputs.has_changes == 'true'
         uses: actions/upload-artifact@v4
         with:
           name: widget-patch
@@ -152,7 +95,7 @@ jobs:
           if-no-files-found: error
 
       - name: Upload release notes patch artifact
-        if: steps.check_changes.outputs.has_changes == 'true'
+        if: steps.workflow_outputs.outputs.has_changes == 'true'
         uses: actions/upload-artifact@v4
         with:
           name: release-notes-patch

--- a/.gitignore
+++ b/.gitignore
@@ -215,5 +215,5 @@ design/
 .agents/**
 
 # Workflow temp files
-changelog_output.txt
+changelog_workflow_result.json
 prompt-exports/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@ This repository is the canonical source for ZenML release metadata and GitBook r
 - `changelog.json` stores dashboard announcement entries, newest first.
 - `gitbook-release-notes/server-sdk.md` contains OSS release notes; `pro-control-plane.md` contains Pro release notes.
 - `changelog_schema/` documents and validates the `changelog.json` format.
-- `scripts/` contains the Python automation: `update_changelog.py`, `source_windows.py`, `consumed_sources.py`, and validation/sync helpers.
+- `scripts/` contains the Python automation: `update_changelog.py`, `workflow_result.py`, `source_windows.py`, `consumed_sources.py`, and validation/sync helpers.
 - `tests/` contains pytest coverage for changelog generation and consumed-source replay prevention.
 - `.github/workflows/` runs dispatch processing, schema validation, and release-note sync workflows.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,6 +23,7 @@ This repo is the canonical source of ZenML release metadata:
   - `announcement-schema.json` — Validation schema for `changelog.json`.
   - `README.md` — Field documentation and examples.
 - `scripts/update_changelog.py` — High-level automation flow (LLM summaries, JSON/markdown writes, image rotation, validation).
+- `scripts/workflow_result.py` — Deterministic workflow-result JSON model and GitHub Actions output writer.
 - `scripts/consumed_sources.py` — Consumed-window/PR ledger models, structured provenance, and read-time validation.
 - `scripts/source_windows.py` — Source-window resolution, replay prevention, and PR collection.
 - `scripts/validate_changelog.py` — Standalone schema validation (used by pre-commit hook).
@@ -43,7 +44,7 @@ This repo is the canonical source of ZenML release metadata:
   - **Pro Path**: Triggered by `zenml-io/zenml-cloud-api` release → aggregates PRs from zenml-cloud-api + zenml-cloud-ui → updates `pro-control-plane.md`
 - Workflow: `.github/workflows/process-release.yml`
   - Uses `uv run` to execute the script (deps declared inline via PEP 723).
-  - Runs `scripts/update_changelog.py` with payload env vars (`SOURCE_REPO`, `RELEASE_TAG`, `RELEASE_URL`, `PUBLISHED_AT`, etc.).
+  - Runs `scripts/update_changelog.py` with payload env vars (`SOURCE_REPO`, `RELEASE_TAG`, `RELEASE_URL`, `PUBLISHED_AT`, etc.), then uses `scripts/workflow_result.py write-github-outputs` to publish the stable workflow outputs.
   - Validates `changelog.json` against `changelog_schema/announcement-schema.json` via `cardinalby/schema-validator-action@v3`.
   - Opens **two PRs** with separate ownership:
     - **Widget PR** (`changelog/{repo_slug}/{tag}`): Updates `changelog.json` and `.image_state` only. Reviewers: `htahir1,znegrin,strickvl`. Labels: `internal,x-squad`.
@@ -57,7 +58,7 @@ This repo is the canonical source of ZenML release metadata:
   - Prepends entries to `changelog.json`, validates against `announcement-schema.json`.
   - Rotates header image using `.image_state` (cycles 1–49).
   - Generates markdown section (OSS links PRs; Pro omits PR links) and inserts after frontmatter in the appropriate file.
-  - Updates `.consumed_sources_state` only after successful changelog and markdown updates, then prints source-window metadata for PR bodies.
+  - Updates `.consumed_sources_state` only after successful changelog and markdown updates, then writes structured source-window metadata for PR bodies to `changelog_workflow_result.json`.
   - Prints summary and exits; workflow keeps `.consumed_sources_state` in the release-notes PR, so a source window is only marked consumed when the markdown that represents it is merged.
 
 ## Manually Adding Changelog Entries

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ zenml-changelog/
 │   └── README.md                   # Field documentation
 ├── scripts/
 │   ├── update_changelog.py         # High-level automation flow and LLM/write steps
+│   ├── workflow_result.py          # Structured workflow handoff and GitHub output writer
 │   ├── consumed_sources.py         # Consumed-window/PR ledger models and validation
 │   └── source_windows.py           # Source-window resolution and PR collection
 ├── .github/workflows/
@@ -42,6 +43,7 @@ flowchart TD
 
 - Trigger: One of two trigger repos (`zenml-io/zenml` or `zenml-io/zenml-cloud-api`) emits `repository_dispatch` (`release-published`).
 - Receiver: `.github/workflows/process-release.yml` installs deps, runs `scripts/update_changelog.py`, validates `changelog.json`, then opens two PRs with reviewers and labels based on ownership: a widget PR for dashboard files and a release-notes PR for markdown plus the consumed-source ledger.
+- Workflow handoff: `scripts/update_changelog.py` writes deterministic machine metadata to `changelog_workflow_result.json` (or the `CHANGELOG_WORKFLOW_RESULT` path). The workflow then runs `scripts/workflow_result.py write-github-outputs` to publish the stable GitHub Actions outputs: `has_changes`, `markdown_file`, `breaking_changes`, `needs_attention`, and `source_windows`. Stdout is only for human-readable logs, not workflow parsing.
 - Script tasks: resolve each source repo's release window, skip windows/PRs already recorded in `.consumed_sources_state`, fetch `release-notes` PRs from the remaining bundled source windows, aggregate and deduplicate, generate 2-3 grouped changelog entries (Anthropic structured outputs), rotate header image, update markdown, validate JSON, and update the consumed-source ledger after successful output.
 - Breaking changes detection: PRs labeled `breaking-change` (and variants) are detected independently of `release-notes` and highlighted in a dedicated `### Breaking Changes` section near the top of release notes. Major version bumps always include this section (with a manual review prompt if no breaking PRs are found).
 

--- a/scripts/source_windows.py
+++ b/scripts/source_windows.py
@@ -27,8 +27,6 @@ except ModuleNotFoundError:  # pragma: no cover - direct `uv run scripts/update_
         pr_key_from_dict,
     )
 
-SOURCE_WINDOWS_START_MARKER = "SOURCE_WINDOWS"
-SOURCE_WINDOWS_END_MARKER = "END_SOURCE_WINDOWS"
 SKIP_REASON_NO_RELEASES_FOUND = "no_releases_found"
 SKIP_REASON_ALREADY_CONSUMED_WINDOW = "already_consumed_window"
 SkipReason = Literal["no_releases_found", "already_consumed_window"]
@@ -271,8 +269,8 @@ def collect_multi_source_prs(
     return result
 
 
-def format_source_window_report(collection: MultiSourceCollectionResult) -> str:
-    lines = [SOURCE_WINDOWS_START_MARKER]
+def _format_source_window_lines(collection: MultiSourceCollectionResult) -> list[str]:
+    lines: list[str] = []
     for source_collection in collection.included_windows:
         window = source_collection.window
         lines.append(
@@ -291,5 +289,9 @@ def format_source_window_report(collection: MultiSourceCollectionResult) -> str:
             f"reason={skipped_window.reason} "
             f"consumed_by={skipped_window.consumed_by_release_tag or '<none>'}"
         )
-    lines.append(SOURCE_WINDOWS_END_MARKER)
-    return "\n".join(lines)
+    return lines
+
+
+def format_source_window_body(collection: MultiSourceCollectionResult) -> str:
+    return "\n".join(_format_source_window_lines(collection))
+

--- a/scripts/update_changelog.py
+++ b/scripts/update_changelog.py
@@ -6,7 +6,7 @@
 #     "PyGithub",
 #     "anthropic",
 #     "jsonschema",
-#     "pydantic",
+#     "pydantic>=2",
 #     "python-slugify",
 #     "tenacity",
 # ]
@@ -44,11 +44,18 @@ try:
     )
     from scripts.source_windows import (
         SKIP_REASON_ALREADY_CONSUMED_WINDOW,
-        SOURCE_WINDOWS_END_MARKER,
-        SOURCE_WINDOWS_START_MARKER,
         MultiSourceCollectionResult,
         collect_multi_source_prs as _collect_multi_source_prs,
-        format_source_window_report,
+        format_source_window_body,
+    )
+    from scripts.workflow_result import (
+        ChangelogWorkflowResult,
+        NeedsAttentionItem,
+        clear_changelog_workflow_result,
+        format_breaking_changes_output,
+        format_needs_attention_output,
+        get_changelog_workflow_result_path,
+        write_changelog_workflow_result,
     )
 except ModuleNotFoundError:  # pragma: no cover - direct `uv run scripts/update_changelog.py`
     from consumed_sources import (  # type: ignore[no-redef]
@@ -65,11 +72,18 @@ except ModuleNotFoundError:  # pragma: no cover - direct `uv run scripts/update_
     )
     from source_windows import (  # type: ignore[no-redef]
         SKIP_REASON_ALREADY_CONSUMED_WINDOW,
-        SOURCE_WINDOWS_END_MARKER,
-        SOURCE_WINDOWS_START_MARKER,
         MultiSourceCollectionResult,
         collect_multi_source_prs as _collect_multi_source_prs,
-        format_source_window_report,
+        format_source_window_body,
+    )
+    from workflow_result import (  # type: ignore[no-redef]
+        ChangelogWorkflowResult,
+        NeedsAttentionItem,
+        clear_changelog_workflow_result,
+        format_breaking_changes_output,
+        format_needs_attention_output,
+        get_changelog_workflow_result_path,
+        write_changelog_workflow_result,
     )
 
 IMAGE_STATE_FILE = Path(".image_state")
@@ -224,6 +238,7 @@ class BreakingChangesOutput(BaseModel):
         description="List of breaking change bullet points, one per significant breaking change.",
     )
 
+
 class ImageState(BaseModel):
     last_image_number: int = Field(default=0, ge=0, le=MAX_IMAGE_NUMBER)
     last_release_tag: Optional[str] = None
@@ -269,8 +284,10 @@ def _model_dump(model: BaseModel) -> Dict[str, Any]:
     return model.model_dump() if hasattr(model, "model_dump") else model.dict()  # type: ignore[attr-defined]
 
 
+
 def write_image_state(state: ImageState, path: Path = IMAGE_STATE_FILE) -> None:
     path.write_text(json.dumps(_model_dump(state), indent=2, sort_keys=True) + "\n")
+
 
 
 def infer_latest_image_from_markdown(md_path: Path) -> Optional[int]:
@@ -940,9 +957,9 @@ def is_short_body(pr_body: str, threshold: int = 50) -> bool:
 def collect_needs_attention(
     prs: List[Dict[str, Any]],
     threshold: int = 50,
-) -> List[Dict[str, str]]:
+) -> List[NeedsAttentionItem]:
     """Identify PRs with insufficient bodies that should be highlighted for manual review."""
-    needs_attention: List[Dict[str, str]] = []
+    needs_attention: List[NeedsAttentionItem] = []
     for pr in prs:
         if is_short_body(pr.get("body", ""), threshold=threshold):
             needs_attention.append(
@@ -1209,6 +1226,9 @@ def get_release_info(gh: Github, repo_name: str, tag: str) -> tuple[str, str]:
 
 
 def main() -> None:
+    workflow_result_path = get_changelog_workflow_result_path()
+    clear_changelog_workflow_result(workflow_result_path)
+
     env = ensure_required_env(
         ["SOURCE_REPO", "RELEASE_TAG", "GITHUB_TOKEN", "ANTHROPIC_API_KEY"]
     )
@@ -1242,7 +1262,10 @@ def main() -> None:
         trigger_release_tag=env["RELEASE_TAG"],
         consumed_state=consumed_state,
     )
-    print(format_source_window_report(collection))
+    source_windows_body = format_source_window_body(collection)
+    if source_windows_body:
+        print("Source windows:")
+        print(source_windows_body)
 
     release_notes_prs = collection.release_notes_prs
     print(f"Found {len(release_notes_prs)} PRs with release-notes label across all sources")
@@ -1256,8 +1279,23 @@ def main() -> None:
 
     if not release_notes_prs and not breaking_prs:
         print("No release-notes or breaking-change PRs found for this release. Nothing to do.")
-        print("NO_CHANGES_NEEDED")
+        write_changelog_workflow_result(
+            ChangelogWorkflowResult(
+                has_changes=False,
+                markdown_file=config["markdown_file"],
+                breaking_changes="",
+                needs_attention="",
+                source_windows=source_windows_body,
+            ),
+            workflow_result_path,
+        )
         raise SystemExit(0)
+
+    if not source_windows_body.strip():
+        raise RuntimeError(
+            "Release-note or breaking-change PRs were collected, but the source-window body is empty. "
+            "Refusing to write changelog artifacts without source-window metadata."
+        )
 
     # Use release-notes PRs for changelog entries; fall back to breaking PRs if none
     grouping_prs = release_notes_prs if release_notes_prs else breaking_prs
@@ -1336,27 +1374,20 @@ def main() -> None:
         f"{CONSUMED_SOURCE_STATE_FILE}."
     )
 
-    if breaking_section.strip():
-        print()
-        print("BREAKING_CHANGES")
-        # Print just the bullets portion for extraction
-        for bullet in breaking_bullets:
-            print(f"- {bullet}")
-        if major_bump and not breaking_bullets:
-            print("- Major version bump detected; manual review recommended")
-        print("END_BREAKING_CHANGES")
+    write_changelog_workflow_result(
+        ChangelogWorkflowResult(
+            has_changes=True,
+            markdown_file=markdown_file,
+            breaking_changes=format_breaking_changes_output(
+                breaking_bullets,
+                is_major_bump=major_bump,
+            ),
+            needs_attention=format_needs_attention_output(needs_attention),
+            source_windows=source_windows_body,
+        ),
+        workflow_result_path,
+    )
 
-    if needs_attention:
-        print()
-        print("NEEDS_ATTENTION")
-        print("The following PRs had empty or insufficient descriptions and need manual review:")
-        for pr in needs_attention:
-            print(f"- PR #{pr['number']}: {pr['title']} ({pr['url']})")
-
-    print()
-    print("UPDATED_MARKDOWN_FILE")
-    print(config["markdown_file"])
-    print("END_UPDATED_MARKDOWN_FILE")
 
 if __name__ == "__main__":
     main()

--- a/scripts/workflow_result.py
+++ b/scripts/workflow_result.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "pydantic>=2",
+# ]
+# ///
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+from typing import List, Sequence, TypedDict
+
+from pydantic import BaseModel, ConfigDict, StrictBool, StrictStr, ValidationError, model_validator
+
+DEFAULT_CHANGELOG_WORKFLOW_RESULT_FILE = Path("changelog_workflow_result.json")
+CHANGELOG_WORKFLOW_RESULT_ENV = "CHANGELOG_WORKFLOW_RESULT"
+GITHUB_OUTPUT_ENV = "GITHUB_OUTPUT"
+NEEDS_ATTENTION_HEADER = "The following PRs had empty or insufficient descriptions and need manual review:"
+GITHUB_MULTILINE_OUTPUT_FIELDS = (
+    "markdown_file",
+    "breaking_changes",
+    "needs_attention",
+    "source_windows",
+)
+ALLOWED_MARKDOWN_FILES = frozenset(
+    {
+        "gitbook-release-notes/server-sdk.md",
+        "gitbook-release-notes/pro-control-plane.md",
+    }
+)
+
+
+class NeedsAttentionItem(TypedDict):
+    number: str
+    title: str
+    url: str
+
+
+class ChangelogWorkflowResult(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    has_changes: StrictBool
+    markdown_file: StrictStr
+    breaking_changes: StrictStr
+    needs_attention: StrictStr
+    source_windows: StrictStr
+
+    @model_validator(mode="after")
+    def require_changed_artifacts(self) -> "ChangelogWorkflowResult":
+        if self.markdown_file:
+            if any(ord(char) < 32 or ord(char) == 127 for char in self.markdown_file):
+                raise ValueError("markdown_file must not contain control characters")
+            if self.markdown_file not in ALLOWED_MARKDOWN_FILES:
+                raise ValueError("markdown_file must be a known release-notes target")
+
+        if self.has_changes:
+            if not self.markdown_file.strip():
+                raise ValueError("markdown_file is required when has_changes is true")
+            if not self.source_windows.strip():
+                raise ValueError("source_windows is required when has_changes is true")
+        return self
+
+
+def get_changelog_workflow_result_path() -> Path:
+    return Path(os.environ.get(CHANGELOG_WORKFLOW_RESULT_ENV, DEFAULT_CHANGELOG_WORKFLOW_RESULT_FILE))
+
+
+def clear_changelog_workflow_result(path: Path) -> None:
+    try:
+        path.unlink()
+    except FileNotFoundError:
+        return
+
+
+def write_changelog_workflow_result(
+    result: ChangelogWorkflowResult,
+    path: Path | None = None,
+) -> None:
+    result_path = path or get_changelog_workflow_result_path()
+    result_path.parent.mkdir(parents=True, exist_ok=True)
+    result_path.write_text(
+        json.dumps(result.model_dump(), indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def read_changelog_workflow_result(path: Path | None = None) -> ChangelogWorkflowResult:
+    result_path = path or get_changelog_workflow_result_path()
+    try:
+        raw = result_path.read_text(encoding="utf-8")
+    except FileNotFoundError as exc:
+        raise RuntimeError(f"Changelog workflow result file not found: {result_path}") from exc
+
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(f"Invalid changelog workflow result JSON in {result_path}: {exc}") from exc
+
+    if not isinstance(payload, dict):
+        raise RuntimeError(f"Invalid changelog workflow result in {result_path}: expected object")
+
+    try:
+        return ChangelogWorkflowResult.model_validate(payload)
+    except ValidationError as exc:
+        raise RuntimeError(f"Invalid changelog workflow result in {result_path}: {exc}") from exc
+
+
+def _github_output_delimiter(name: str, value_lines: Sequence[str]) -> str:
+    base = f"ZENML_CHANGELOG_OUTPUT_{name.upper()}"
+    value_line_set = set(value_lines)
+    delimiter = base
+    suffix = 1
+    while delimiter in value_line_set:
+        delimiter = f"{base}_{suffix}"
+        suffix += 1
+    return delimiter
+
+
+def _append_github_scalar_output(lines: List[str], name: str, value: str) -> None:
+    lines.append(f"{name}={value}")
+
+
+def _append_github_multiline_output(lines: List[str], name: str, value: str) -> None:
+    value_lines = value.splitlines()
+    delimiter = _github_output_delimiter(name, value_lines)
+    lines.append(f"{name}<<{delimiter}")
+    lines.extend(value_lines)
+    lines.append(delimiter)
+
+
+def write_changelog_github_outputs(
+    result: ChangelogWorkflowResult,
+    output_path: Path,
+) -> None:
+    lines: List[str] = []
+    _append_github_scalar_output(lines, "has_changes", "true" if result.has_changes else "false")
+    for field_name in GITHUB_MULTILINE_OUTPUT_FIELDS:
+        _append_github_multiline_output(lines, field_name, getattr(result, field_name))
+    with output_path.open("a", encoding="utf-8") as output_file:
+        output_file.write("\n".join(lines) + "\n")
+
+
+def require_env(name: str) -> str:
+    value = os.environ.get(name)
+    if value is None:
+        raise RuntimeError(f"Missing required environment variable: {name}")
+    return value
+
+
+def run_write_github_outputs_mode() -> None:
+    output_path = require_env(GITHUB_OUTPUT_ENV)
+    result = read_changelog_workflow_result()
+    write_changelog_github_outputs(result, Path(output_path))
+
+
+def format_breaking_changes_output(
+    bullets: List[str],
+    *,
+    is_major_bump: bool,
+) -> str:
+    cleaned = [bullet.strip() for bullet in bullets if bullet.strip()]
+    if cleaned:
+        return "\n".join(f"- {bullet}" for bullet in cleaned)
+    if is_major_bump:
+        return "- Major version bump detected; manual review recommended"
+    return ""
+
+
+def format_needs_attention_output(needs_attention: List[NeedsAttentionItem]) -> str:
+    if not needs_attention:
+        return ""
+    lines = [NEEDS_ATTENTION_HEADER]
+    for pr in needs_attention:
+        if pr["url"]:
+            lines.append(f"- PR #{pr['number']}: {pr['title']} ({pr['url']})")
+        else:
+            lines.append(f"- {pr['title']}")
+    return "\n".join(lines)
+
+
+def cli(argv: Sequence[str] | None = None) -> None:
+    args = list(sys.argv[1:] if argv is None else argv)
+    if args == ["write-github-outputs"]:
+        run_write_github_outputs_mode()
+        return
+    raise SystemExit("Usage: workflow_result.py write-github-outputs")
+
+
+if __name__ == "__main__":
+    cli()

--- a/tests/test_consumed_source_windows.py
+++ b/tests/test_consumed_source_windows.py
@@ -367,7 +367,7 @@ def test_consumed_pr_key_is_filtered_even_when_window_is_new(
     assert ui_collection.filtered_pr_keys == ["zenml-io/zenml-cloud-ui#1317"]
 
 
-def test_source_window_report_exposes_included_and_skipped_windows(
+def test_source_window_body_exposes_included_and_skipped_windows(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     patch_release_window_resolution(monkeypatch)
@@ -379,13 +379,13 @@ def test_source_window_report_exposes_included_and_skipped_windows(
         consumed_state=consumed_ui_01314_to_01315_state(),
     )
 
-    report = uc.format_source_window_report(collection)
+    body = uc.format_source_window_body(collection)
 
-    assert report.startswith(f"{uc.SOURCE_WINDOWS_START_MARKER}\n")
-    assert "included zenml-io/zenml-cloud-api 0.13.15 -> 0.13.16" in report
-    assert "skipped zenml-io/zenml-cloud-ui 0.13.14 -> 0.13.15" in report
-    assert "reason=already_consumed_window" in report
-    assert report.endswith(f"\n{uc.SOURCE_WINDOWS_END_MARKER}")
+    assert "SOURCE_WINDOWS" not in body.splitlines()
+    assert "END_SOURCE_WINDOWS" not in body.splitlines()
+    assert "included zenml-io/zenml-cloud-api 0.13.15 -> 0.13.16" in body
+    assert "skipped zenml-io/zenml-cloud-ui 0.13.14 -> 0.13.15" in body
+    assert "reason=already_consumed_window" in body
 
 def test_image_state_remains_separate_from_consumed_source_state(tmp_path: Path) -> None:
     image_state_path = tmp_path / ".image_state"

--- a/tests/test_update_changelog_main.py
+++ b/tests/test_update_changelog_main.py
@@ -1,0 +1,164 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from scripts import source_windows as sw
+from scripts import update_changelog as uc
+from scripts import workflow_result as wr
+
+
+class FakeAnthropic:
+    def __init__(self, api_key: str) -> None:
+        self.api_key = api_key
+
+
+class FakeGithub:
+    def __init__(self, auth: object) -> None:
+        self.auth = auth
+
+
+def make_pr(number: int, body: str = "short") -> dict[str, Any]:
+    return {
+        "number": number,
+        "title": f"PR {number}",
+        "labels": ["release-notes"],
+        "url": f"https://github.com/zenml-io/zenml/pull/{number}",
+        "body": body,
+        "repo": "zenml-io/zenml",
+    }
+
+
+def make_collection(
+    *,
+    release_notes_prs: list[dict[str, Any]],
+    breaking_prs: list[dict[str, Any]],
+) -> uc.MultiSourceCollectionResult:
+    window = sw.SourceReleaseWindow(
+        source_repo="zenml-io/zenml",
+        base_branch="develop",
+        previous_tag="0.84.0",
+        current_tag="0.85.0",
+        since_date=uc.datetime(2026, 6, 1, tzinfo=uc.timezone.utc),
+        until_date=uc.datetime(2026, 6, 2, tzinfo=uc.timezone.utc),
+        is_primary=True,
+    )
+    return uc.MultiSourceCollectionResult(
+        included_windows=[
+            sw.SourceWindowCollection(
+                window=window,
+                release_notes_prs=release_notes_prs,
+                breaking_prs=breaking_prs,
+            )
+        ],
+        release_notes_prs=release_notes_prs,
+        breaking_prs=breaking_prs,
+    )
+
+
+def configure_common_main_stubs(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> Path:
+    result_path = tmp_path / "workflow-result.json"
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("SOURCE_REPO", "zenml-io/zenml")
+    monkeypatch.setenv("RELEASE_TAG", "0.85.0")
+    monkeypatch.setenv("GITHUB_TOKEN", "token")
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "anthropic-token")
+    monkeypatch.setenv("RELEASE_URL", "https://github.com/zenml-io/zenml/releases/tag/0.85.0")
+    monkeypatch.setenv("PUBLISHED_AT", "2026-06-02T10:00:00Z")
+    monkeypatch.setenv(wr.CHANGELOG_WORKFLOW_RESULT_ENV, str(result_path))
+    monkeypatch.setattr(uc, "Anthropic", FakeAnthropic)
+    monkeypatch.setattr(uc, "Github", FakeGithub)
+    monkeypatch.setattr(uc, "find_previous_tag", lambda *args: "0.84.0")
+    monkeypatch.setattr(uc, "read_consumed_source_state", lambda: uc.ConsumedSourceState())
+    return result_path
+
+
+def test_main_no_changes_writes_structured_result_and_exits_cleanly(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    result_path = configure_common_main_stubs(monkeypatch, tmp_path)
+    monkeypatch.setattr(
+        uc,
+        "collect_multi_source_prs",
+        lambda **kwargs: uc.MultiSourceCollectionResult(),
+    )
+
+    with pytest.raises(SystemExit) as exit_info:
+        uc.main()
+
+    assert exit_info.value.code == 0
+    result = wr.read_changelog_workflow_result(result_path)
+    assert result.has_changes is False
+    assert result.markdown_file == "gitbook-release-notes/server-sdk.md"
+    assert result.breaking_changes == ""
+    assert result.needs_attention == ""
+    assert result.source_windows == ""
+
+
+def test_main_happy_path_writes_structured_result(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    result_path = configure_common_main_stubs(monkeypatch, tmp_path)
+    release_pr = make_pr(1, body="short")
+    breaking_pr = make_pr(2, body="This breaking PR has enough body text to avoid manual-review noise.")
+    collection = make_collection(
+        release_notes_prs=[release_pr],
+        breaking_prs=[breaking_pr],
+    )
+    (tmp_path / "changelog.json").write_text("[]\n", encoding="utf-8")
+    monkeypatch.setattr(uc, "collect_multi_source_prs", lambda **kwargs: collection)
+    monkeypatch.setattr(
+        uc,
+        "llm_generate_breaking_changes_bullets",
+        lambda **kwargs: ["Breaking API changed"],
+    )
+    monkeypatch.setattr(
+        uc,
+        "generate_valid_grouped_changelog_entries",
+        lambda **kwargs: [
+            {
+                "id": kwargs["starting_id"],
+                "title": "Grouped release note",
+                "description": "Grouped release note description",
+                "label": "improvement",
+                "source_prs": [1],
+                "source_repo": "zenml-io/zenml",
+                "published_at": "2026-06-02T10:00:00Z",
+            }
+        ],
+    )
+    monkeypatch.setattr(uc, "validate_changelog", lambda *args, **kwargs: None)
+    monkeypatch.setattr(uc, "get_next_image_number", lambda **kwargs: 3)
+    monkeypatch.setattr(uc, "render_release_header", lambda *args, **kwargs: "HEADER\n")
+    monkeypatch.setattr(uc, "render_breaking_section", lambda *args, **kwargs: "BREAKING\n")
+    monkeypatch.setattr(uc, "llm_generate_release_notes_body", lambda *args, **kwargs: "BODY")
+    monkeypatch.setattr(uc, "render_release_footer", lambda *args, **kwargs: "FOOTER")
+    monkeypatch.setattr(uc, "update_markdown_file", lambda *args, **kwargs: None)
+    monkeypatch.setattr(uc, "mark_consumed_after_success", lambda **kwargs: kwargs["state"])
+    monkeypatch.setattr(uc, "write_consumed_source_state", lambda *args, **kwargs: None)
+
+    uc.main()
+
+    result = wr.read_changelog_workflow_result(result_path)
+    assert result.has_changes is True
+    assert result.markdown_file == "gitbook-release-notes/server-sdk.md"
+    assert result.breaking_changes == "- Breaking API changed"
+    assert result.needs_attention == (
+        f"{wr.NEEDS_ATTENTION_HEADER}\n"
+        "- PR #1: PR 1 (https://github.com/zenml-io/zenml/pull/1)"
+    )
+    assert "included zenml-io/zenml 0.84.0 -> 0.85.0" in result.source_windows
+    assert "release_notes=1" in result.source_windows
+    assert "breaking=1" in result.source_windows

--- a/tests/test_update_changelog_workflow_result.py
+++ b/tests/test_update_changelog_workflow_result.py
@@ -1,0 +1,281 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from scripts import workflow_result as wr
+
+
+def make_result(**overrides: object) -> wr.ChangelogWorkflowResult:
+    payload = {
+        "has_changes": True,
+        "markdown_file": "gitbook-release-notes/server-sdk.md",
+        "breaking_changes": "- Removed old behavior",
+        "needs_attention": "",
+        "source_windows": "included zenml-io/zenml 0.84.0 -> 0.85.0 release_notes=2 breaking=1 filtered=0",
+    }
+    payload.update(overrides)
+    return wr.ChangelogWorkflowResult(**payload)
+
+
+def test_workflow_result_accepts_valid_changes_result() -> None:
+    result = make_result()
+
+    assert result.has_changes is True
+    assert result.markdown_file == "gitbook-release-notes/server-sdk.md"
+
+
+def test_workflow_result_is_frozen() -> None:
+    result = make_result()
+
+    with pytest.raises(wr.ValidationError, match="frozen"):
+        result.markdown_file = "gitbook-release-notes/pro-control-plane.md"
+
+
+@pytest.mark.parametrize("field", ["markdown_file", "source_windows"])
+def test_changes_result_requires_artifact_fields(field: str) -> None:
+    with pytest.raises(wr.ValidationError, match=field):
+        make_result(**{field: ""})
+
+
+def test_no_changes_result_allows_empty_artifact_fields() -> None:
+    result = wr.ChangelogWorkflowResult(
+        has_changes=False,
+        markdown_file="",
+        breaking_changes="",
+        needs_attention="",
+        source_windows="",
+    )
+
+    assert result.has_changes is False
+
+
+@pytest.mark.parametrize("value", ["true", "false"])
+def test_workflow_result_rejects_string_booleans(value: str) -> None:
+    with pytest.raises(wr.ValidationError):
+        make_result(has_changes=value)
+
+
+@pytest.mark.parametrize(
+    "markdown_file",
+    [
+        "gitbook-release-notes/unknown.md",
+        "gitbook-release-notes/server-sdk.md\nother=value",
+    ],
+)
+def test_workflow_result_rejects_invalid_non_empty_markdown_file(markdown_file: str) -> None:
+    with pytest.raises(wr.ValidationError, match="markdown_file"):
+        make_result(markdown_file=markdown_file)
+
+
+def test_workflow_result_json_round_trip_is_deterministic(tmp_path: Path) -> None:
+    path = tmp_path / "result.json"
+    result = make_result(needs_attention="Needs review")
+
+    wr.write_changelog_workflow_result(result, path)
+
+    assert path.read_text(encoding="utf-8") == (
+        "{\n"
+        '  "breaking_changes": "- Removed old behavior",\n'
+        '  "has_changes": true,\n'
+        '  "markdown_file": "gitbook-release-notes/server-sdk.md",\n'
+        '  "needs_attention": "Needs review",\n'
+        '  "source_windows": "included zenml-io/zenml 0.84.0 -> 0.85.0 release_notes=2 breaking=1 filtered=0"\n'
+        "}\n"
+    )
+    loaded = wr.read_changelog_workflow_result(path)
+    assert loaded == result
+
+
+def test_read_workflow_result_fails_closed_for_missing_file(tmp_path: Path) -> None:
+    with pytest.raises(RuntimeError, match="not found"):
+        wr.read_changelog_workflow_result(tmp_path / "missing.json")
+
+
+def test_read_workflow_result_fails_closed_for_invalid_json(tmp_path: Path) -> None:
+    path = tmp_path / "result.json"
+    path.write_text("[not-json]", encoding="utf-8")
+
+    with pytest.raises(RuntimeError, match="Invalid changelog workflow result JSON"):
+        wr.read_changelog_workflow_result(path)
+
+
+def test_read_workflow_result_fails_closed_for_invalid_payload(tmp_path: Path) -> None:
+    path = tmp_path / "result.json"
+    path.write_text('{"has_changes": "true"}\n', encoding="utf-8")
+
+    with pytest.raises(RuntimeError, match="Invalid changelog workflow result"):
+        wr.read_changelog_workflow_result(path)
+
+
+def test_format_breaking_changes_output_preserves_bullets_only_contract() -> None:
+    assert wr.format_breaking_changes_output(
+        ["First change", "", " Second change "],
+        is_major_bump=False,
+    ) == "- First change\n- Second change"
+
+
+def test_format_breaking_changes_output_major_bump_fallback_is_exact() -> None:
+    assert wr.format_breaking_changes_output([], is_major_bump=True) == (
+        "- Major version bump detected; manual review recommended"
+    )
+
+
+def test_format_breaking_changes_output_empty_for_non_major_without_bullets() -> None:
+    assert wr.format_breaking_changes_output([], is_major_bump=False) == ""
+
+
+def test_format_needs_attention_output_is_header_plus_pr_bullets() -> None:
+    output = wr.format_needs_attention_output(
+        [
+            {
+                "number": "123",
+                "title": "Needs a better description",
+                "url": "https://github.com/zenml-io/zenml/pull/123",
+            }
+        ]
+    )
+
+    assert output == (
+        f"{wr.NEEDS_ATTENTION_HEADER}\n"
+        "- PR #123: Needs a better description (https://github.com/zenml-io/zenml/pull/123)"
+    )
+
+
+def test_format_needs_attention_output_empty_when_no_prs() -> None:
+    assert wr.format_needs_attention_output([]) == ""
+
+
+def test_format_needs_attention_output_renders_empty_url_as_plain_note() -> None:
+    output = wr.format_needs_attention_output(
+        [
+            {
+                "number": "N/A",
+                "title": "No release-notes PRs found; changelog derived from breaking PRs only",
+                "url": "",
+            }
+        ]
+    )
+
+    assert output == (
+        f"{wr.NEEDS_ATTENTION_HEADER}\n"
+        "- No release-notes PRs found; changelog derived from breaking PRs only"
+    )
+
+
+def test_github_output_writer_writes_all_stable_output_names(tmp_path: Path) -> None:
+    path = tmp_path / "github-output.txt"
+    result = make_result(
+        breaking_changes="- Breaking one\n- Breaking two",
+        needs_attention=f"{wr.NEEDS_ATTENTION_HEADER}\n- PR #123: Needs review (https://example.test/pr/123)",
+    )
+
+    wr.write_changelog_github_outputs(result, path)
+
+    output = path.read_text(encoding="utf-8")
+    assert output == (
+        "has_changes=true\n"
+        "markdown_file<<ZENML_CHANGELOG_OUTPUT_MARKDOWN_FILE\n"
+        "gitbook-release-notes/server-sdk.md\n"
+        "ZENML_CHANGELOG_OUTPUT_MARKDOWN_FILE\n"
+        "breaking_changes<<ZENML_CHANGELOG_OUTPUT_BREAKING_CHANGES\n"
+        "- Breaking one\n"
+        "- Breaking two\n"
+        "ZENML_CHANGELOG_OUTPUT_BREAKING_CHANGES\n"
+        "needs_attention<<ZENML_CHANGELOG_OUTPUT_NEEDS_ATTENTION\n"
+        f"{wr.NEEDS_ATTENTION_HEADER}\n"
+        "- PR #123: Needs review (https://example.test/pr/123)\n"
+        "ZENML_CHANGELOG_OUTPUT_NEEDS_ATTENTION\n"
+        "source_windows<<ZENML_CHANGELOG_OUTPUT_SOURCE_WINDOWS\n"
+        "included zenml-io/zenml 0.84.0 -> 0.85.0 release_notes=2 breaking=1 filtered=0\n"
+        "ZENML_CHANGELOG_OUTPUT_SOURCE_WINDOWS\n"
+    )
+
+
+def test_github_output_writer_handles_empty_multiline_values(tmp_path: Path) -> None:
+    path = tmp_path / "github-output.txt"
+    result = wr.ChangelogWorkflowResult(
+        has_changes=False,
+        markdown_file="",
+        breaking_changes="",
+        needs_attention="",
+        source_windows="",
+    )
+
+    wr.write_changelog_github_outputs(result, path)
+
+    output = path.read_text(encoding="utf-8")
+    assert "has_changes=false\n" in output
+    assert "breaking_changes<<ZENML_CHANGELOG_OUTPUT_BREAKING_CHANGES\nZENML_CHANGELOG_OUTPUT_BREAKING_CHANGES\n" in output
+
+
+def test_github_output_writer_avoids_delimiter_line_collision(tmp_path: Path) -> None:
+    path = tmp_path / "github-output.txt"
+    result = make_result(
+        source_windows=(
+            "included zenml-io/zenml 0.84.0 -> 0.85.0 release_notes=2 breaking=1 filtered=0\n"
+            "ZENML_CHANGELOG_OUTPUT_SOURCE_WINDOWS"
+        )
+    )
+
+    wr.write_changelog_github_outputs(result, path)
+
+    output = path.read_text(encoding="utf-8")
+    assert "source_windows<<ZENML_CHANGELOG_OUTPUT_SOURCE_WINDOWS_1\n" in output
+    assert output.endswith("ZENML_CHANGELOG_OUTPUT_SOURCE_WINDOWS_1\n")
+
+
+def test_write_github_outputs_mode_reads_result_and_requires_output_env(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    result_path = tmp_path / "result.json"
+    output_path = tmp_path / "github-output.txt"
+    wr.write_changelog_workflow_result(make_result(), result_path)
+    monkeypatch.setenv(wr.CHANGELOG_WORKFLOW_RESULT_ENV, str(result_path))
+    monkeypatch.setenv(wr.GITHUB_OUTPUT_ENV, str(output_path))
+
+    wr.run_write_github_outputs_mode()
+
+    output = output_path.read_text(encoding="utf-8")
+    assert "has_changes=true\n" in output
+
+
+def test_write_github_outputs_mode_fails_without_output_env(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    result_path = tmp_path / "result.json"
+    wr.write_changelog_workflow_result(make_result(), result_path)
+    monkeypatch.setenv(wr.CHANGELOG_WORKFLOW_RESULT_ENV, str(result_path))
+    monkeypatch.delenv(wr.GITHUB_OUTPUT_ENV, raising=False)
+
+    with pytest.raises(RuntimeError, match=wr.GITHUB_OUTPUT_ENV):
+        wr.run_write_github_outputs_mode()
+
+
+def test_cli_dispatches_write_github_outputs_mode(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    result_path = tmp_path / "result.json"
+    output_path = tmp_path / "github-output.txt"
+    wr.write_changelog_workflow_result(make_result(), result_path)
+    monkeypatch.setenv(wr.CHANGELOG_WORKFLOW_RESULT_ENV, str(result_path))
+    monkeypatch.setenv(wr.GITHUB_OUTPUT_ENV, str(output_path))
+
+    wr.cli(["write-github-outputs"])
+
+    output = output_path.read_text(encoding="utf-8")
+    assert "source_windows<<ZENML_CHANGELOG_OUTPUT_SOURCE_WINDOWS\n" in output
+
+
+def test_cli_rejects_unknown_args() -> None:
+    with pytest.raises(SystemExit, match="Usage: workflow_result.py"):
+        wr.cli(["unknown"])


### PR DESCRIPTION
## Summary
- Replace `process-release.yml` stdout marker scraping with a typed JSON workflow handoff.
- Add `scripts/workflow_result.py` to validate `changelog_workflow_result.json` and publish stable GitHub Actions outputs.
- Remove the dead source-window marker protocol from production code and keep marker-free source-window body formatting.
- Add focused tests for result validation, GitHub output formatting, no-changes and happy-path `update_changelog.py` behavior.
- Update README, AGENTS.md, and CLAUDE.md to document the structured handoff and pytest CI contract.

## Validation
- `uv run scripts/run_pytest.py` → 72 passed
- Simplify review run; targeted cleanup applied
- Thermonuclear code quality review run; structural cleanup applied
- Oracle review run; no must-fix findings
- Oracle follow-up after final hardening; no new must-fix findings
