### PR TITLE
Handle truncated OpenAI release notes output

### DIFF
--- a/scripts/changelog_llm_generation.py
+++ b/scripts/changelog_llm_generation.py
@@ -101,7 +101,7 @@ def generate_release_notes_body_output(
     output = client.parse_structured_output(
         prompt=prompt,
         output_model=MarkdownSection,
-        max_output_tokens=1800,
+        max_output_tokens=6000,
         call_name=LLM_CALL_RELEASE_NOTES_BODY,
     )
     warnings = validate_release_notes_body_output(

--- a/scripts/changelog_llm_providers.py
+++ b/scripts/changelog_llm_providers.py
@@ -185,6 +185,16 @@ class OpenAIStructuredLLMClient:
             OpenAIAPIError,
         ) as error:
             raise LLMProviderRetryableError(str(error)) from error
+        except ValidationError as error:
+            if any(detail.get("type") == "json_invalid" for detail in error.errors()):
+                raise LLMProviderNonRetryableError(
+                    f"OpenAI structured output for {call_name} contained invalid JSON before "
+                    f"the response status could be inspected: {error}. If the raw JSON was "
+                    "truncated, increase the max_output_tokens cap or inspect the prompt."
+                ) from error
+            raise LLMProviderRetryableError(str(error)) from error
+        except ValueError as error:
+            raise LLMProviderRetryableError(str(error)) from error
 
         if getattr(response, "status", None) == "incomplete":
             details = getattr(response, "incomplete_details", None)

--- a/tests/test_changelog_llm_generation.py
+++ b/tests/test_changelog_llm_generation.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from scripts import changelog_llm_generation as generation
+from scripts import changelog_llm_outputs as outputs
+
+
+class RecordingStructuredClient:
+    def __init__(self, output: object) -> None:
+        self.output = output
+        self.calls: list[dict[str, Any]] = []
+
+    def parse_structured_output(self, **kwargs: Any) -> Any:
+        self.calls.append(kwargs)
+        return self.output
+
+
+def test_release_notes_body_generation_uses_raised_output_cap() -> None:
+    client = RecordingStructuredClient(outputs.MarkdownSection(content="Users can now manage runs more clearly."))
+
+    generation.generate_release_notes_body_output(
+        client=client,
+        prs=[
+            {
+                "number": 123,
+                "title": "Improve run management",
+                "body": "Adds clearer run controls.",
+                "labels": ["enhancement"],
+                "url": "https://github.com/zenml-io/zenml/pull/123",
+            }
+        ],
+        source_repo="zenml-io/zenml",
+        include_pr_links=False,
+    )
+
+    assert client.calls[0]["max_output_tokens"] == 6000
+    assert client.calls[0]["call_name"] == outputs.LLM_CALL_RELEASE_NOTES_BODY
+    assert client.calls[0]["output_model"] == outputs.MarkdownSection

--- a/tests/test_update_changelog_llm_provider.py
+++ b/tests/test_update_changelog_llm_provider.py
@@ -44,15 +44,19 @@ class FakeOpenAIResponses:
         status: str = "completed",
         output: list[object] | None = None,
         incomplete_details: object | None = None,
+        parse_error: Exception | None = None,
     ) -> None:
         self.parsed = parsed
         self.status = status
         self.output = output or []
         self.incomplete_details = incomplete_details
+        self.parse_error = parse_error
         self.kwargs: dict[str, Any] | None = None
 
     def parse(self, **kwargs: Any) -> Any:
         self.kwargs = kwargs
+        if self.parse_error is not None:
+            raise self.parse_error
         return SimpleNamespace(
             output_parsed=self.parsed,
             status=self.status,
@@ -69,12 +73,14 @@ class FakeOpenAIClient:
         status: str = "completed",
         output: list[object] | None = None,
         incomplete_details: object | None = None,
+        parse_error: Exception | None = None,
     ) -> None:
         self.responses = FakeOpenAIResponses(
             parsed,
             status=status,
             output=output,
             incomplete_details=incomplete_details,
+            parse_error=parse_error,
         )
 
 
@@ -185,6 +191,63 @@ def test_openai_structured_client_fails_closed_on_incomplete_response() -> None:
             output_model=outputs.BreakingChangesOutput,
             max_output_tokens=100,
             call_name="breaking",
+        )
+
+
+def test_openai_structured_client_explains_invalid_json_before_status_inspection() -> None:
+    with pytest.raises(Exception) as generated_error:
+        outputs.MarkdownSection.model_validate_json('{"content": "unfinished')
+    invalid_json_error = generated_error.value
+    assert invalid_json_error.errors()[0]["type"] == "json_invalid"
+    client = providers.OpenAIStructuredLLMClient(
+        FakeOpenAIClient(None, parse_error=invalid_json_error),
+        model="gpt-test",
+    )
+
+    with pytest.raises(providers.LLMProviderNonRetryableError) as exc_info:
+        client.parse_structured_output(
+            prompt="Summarize",
+            output_model=outputs.MarkdownSection,
+            max_output_tokens=100,
+            call_name=outputs.LLM_CALL_RELEASE_NOTES_BODY,
+        )
+
+    message = str(exc_info.value)
+    assert "contained invalid JSON before the response status could be inspected" in message
+    assert "increase the max_output_tokens cap" in message
+
+
+def test_openai_structured_client_keeps_non_json_validation_errors_retryable() -> None:
+    with pytest.raises(Exception) as generated_error:
+        outputs.MarkdownSection.model_validate({})
+    validation_error = generated_error.value
+    assert validation_error.errors()[0]["type"] != "json_invalid"
+    client = providers.OpenAIStructuredLLMClient(
+        FakeOpenAIClient(None, parse_error=validation_error),
+        model="gpt-test",
+    )
+
+    with pytest.raises(providers.LLMProviderRetryableError, match="content"):
+        client.parse_structured_output(
+            prompt="Summarize",
+            output_model=outputs.MarkdownSection,
+            max_output_tokens=100,
+            call_name=outputs.LLM_CALL_RELEASE_NOTES_BODY,
+        )
+
+
+def test_openai_structured_client_keeps_generic_value_errors_retryable() -> None:
+    client = providers.OpenAIStructuredLLMClient(
+        FakeOpenAIClient(None, parse_error=ValueError("temporary parser failure")),
+        model="gpt-test",
+    )
+
+    with pytest.raises(providers.LLMProviderRetryableError, match="temporary parser failure"):
+        client.parse_structured_output(
+            prompt="Summarize",
+            output_model=outputs.MarkdownSection,
+            max_output_tokens=100,
+            call_name=outputs.LLM_CALL_RELEASE_NOTES_BODY,
         )
 
 


### PR DESCRIPTION
## Summary

- Raise the release-notes body structured-output cap from `1800` to `6000` tokens.
- Add a clearer OpenAI provider error when structured JSON is invalid/truncated before `response.status` can be inspected.
- Preserve retry behavior for non-JSON Pydantic validation failures and generic parser `ValueError`s.
- Add focused unit coverage for the cap and OpenAI parse-failure classification.

## Why

The `zenml-io/zenml@0.96.0` release workflow failed while generating GitBook release notes for 18 PRs. OpenAI started returning the `MarkdownSection` JSON, but the JSON ended mid-string, so Pydantic raised an invalid JSON error before our existing incomplete-response check could run.

## Validation

- `uv run scripts/run_pytest.py tests/test_update_changelog_llm_provider.py tests/test_changelog_llm_generation.py` — `23 passed`
- `uv run scripts/run_pytest.py` — `172 passed`

Oracle reviewed the first implementation. The review flagged a broad `ValueError` catch that would have made unrelated parse failures non-retryable; this PR narrows the non-retryable path to Pydantic `json_invalid` errors and keeps other failures retryable.
