### PR TITLE
Add breaking change label to announcement schema

### DIFF
--- a/changelog_schema/README.md
+++ b/changelog_schema/README.md
@@ -130,10 +130,11 @@ Each changelog item is a JSON object with the following fields. The announcement
 - **Required:** No
 - **Default:** `[]` (empty array)
 - **Allowed Values:** Only the following labels are recognized:
-  - `"feature"` - For new features
-  - `"improvement"` - For enhancements to existing functionality
+  - `"breaking change"` - For changes that break backward compatibility
   - `"bugfix"` - For bug fixes
   - `"deprecation"` - For deprecated features or warnings
+  - `"feature"` - For new features
+  - `"improvement"` - For enhancements to existing functionality
 - **Note:** Any labels not in the allowed list will be filtered out automatically
 - **Example:** `["feature"]`, `["bugfix", "improvement"]`
 

--- a/changelog_schema/announcement-schema.json
+++ b/changelog_schema/announcement-schema.json
@@ -55,7 +55,7 @@
 				"type": "array",
 				"items": {
 					"type": "string",
-					"enum": ["bugfix", "deprecation", "improvement", "feature"]
+					"enum": ["breaking change", "bugfix", "deprecation", "feature", "improvement"]
 				},
 				"default": []
 			}

--- a/scripts/changelog_config.py
+++ b/scripts/changelog_config.py
@@ -73,9 +73,9 @@ LABEL_MAPPING: Dict[str, str] = {
     "enhancement": "improvement",
     "improvement": "improvement",
     "deprecation": "deprecation",
-    "breaking": "deprecation",
-    "breaking-change": "deprecation",
-    "breaking changes": "deprecation",
+    "breaking": "breaking change",
+    "breaking-change": "breaking change",
+    "breaking changes": "breaking change",
 }
 
 BREAKING_CHANGE_LABELS: List[str] = [

--- a/scripts/changelog_llm_outputs.py
+++ b/scripts/changelog_llm_outputs.py
@@ -7,6 +7,7 @@ from typing import List
 from pydantic import BaseModel, ConfigDict, Field
 
 class ChangelogLabel(str, Enum):
+    BREAKING_CHANGE = "breaking change"
     BUGFIX = "bugfix"
     DEPRECATION = "deprecation"
     IMPROVEMENT = "improvement"

--- a/scripts/changelog_prompts.py
+++ b/scripts/changelog_prompts.py
@@ -83,7 +83,7 @@ def build_grouped_changelog_entries_prompt(
         "- Avoid over-specific titles that name one narrow implementation detail when the group covers a broader user benefit.\n"
         "- `pr_numbers` must be a list of the PR numbers from the list above that this entry covers.\n"
         "- Use `suggested_labels` based on the overall theme of the grouped PRs, using only: "
-        "feature, improvement, bugfix, deprecation. Return [] if no label applies.\n"
+        "breaking change, feature, improvement, bugfix, deprecation. Return [] if no label applies.\n"
         "Avoid low-level implementation details and emphasize user-facing value."
     )
 

--- a/tests/test_update_changelog_main.py
+++ b/tests/test_update_changelog_main.py
@@ -314,3 +314,19 @@ def test_blank_private_repo_token_falls_back_to_github_token(
         uc.main()
 
     assert created["auth"] == "auth:token"
+
+
+def test_breaking_change_label_passes_schema_validation() -> None:
+    """A changelog entry with labels=["breaking change"] must validate."""
+    from scripts.changelog_schema_validation import validate_changelog_data
+
+    entry = [{
+        "id": 9999,
+        "slug": "test-breaking-change",
+        "title": "Test",
+        "description": "Test entry.",
+        "published_at": "2026-07-22T12:00:00Z",
+        "labels": ["breaking change"],
+    }]
+    schema_path = REPO_ROOT / "changelog_schema" / "announcement-schema.json"
+    validate_changelog_data(entry, schema_path)  # must not raise


### PR DESCRIPTION
## Summary
Add a dedicated `breaking change` label to the changelog announcement schema so breaking changes can be properly categorized instead of being mapped to `deprecation`.

## Related Issue
Fixes #83

## What changed
- Added `"breaking change"` to the labels enum in `announcement-schema.json`
- Added `BREAKING_CHANGE` to the `ChangelogLabel` Python enum
- Updated `LABEL_MAPPING` to route `breaking`/`breaking-change` variants to the new label instead of `deprecation`
- Updated the grouped-entries prompt to include `breaking change` as a valid label option
- Documented the new label in the schema README
- Added regression test: validates entry with `["breaking change"]` passes schema

## Why this approach
Minimal change — 6 files, +25/-7. Reuses existing label infrastructure. Test proven to fail without the schema change.

## Testing done
- 173/173 pytest tests pass
- Regression test fails without the fix (proven via schema revert)
- `validate_changelog.py` passes against existing `changelog.json`

## Checklist
- [x] Tests added/updated
- [x] Docs updated (README)
- [x] All tests pass
- [x] No unrelated changes bundled
- [x] Fixes #83 referenced
